### PR TITLE
Add ZStack and modifier support for setting zIndex

### DIFF
--- a/Sources/TokamakCore/Modifiers/ModifiedContent.swift
+++ b/Sources/TokamakCore/Modifiers/ModifiedContent.swift
@@ -1,0 +1,43 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// A value with a modifier applied to it.
+public struct ModifiedContent<Content, Modifier> {
+  public typealias Body = Never
+  public let content: Content
+  public let modifier: Modifier
+
+  @inlinable public init(content: Content, modifier: Modifier) {
+    self.content = content
+    self.modifier = modifier
+  }
+}
+
+extension ModifiedContent: View where Content: View, Modifier: ViewModifier {
+  public var body: Body {
+    neverBody("ModifiedContent<View, ViewModifier>")
+  }
+}
+
+extension ModifiedContent: ViewModifier where Content: ViewModifier, Modifier: ViewModifier {
+  public func body(content: _ViewModifier_Content<Self>) -> Never {
+    neverBody("ModifiedContent<ViewModifier, ViewModifier>")
+  }
+}
+
+extension ViewModifier {
+  public func concat<T>(_ modifier: T) -> ModifiedContent<Self, T> where T: ViewModifier {
+    .init(content: self, modifier: modifier)
+  }
+}

--- a/Sources/TokamakCore/Modifiers/ViewModifier.swift
+++ b/Sources/TokamakCore/Modifiers/ViewModifier.swift
@@ -13,22 +13,22 @@
 // limitations under the License.
 
 public protocol ViewModifier {
-    typealias Content = _ViewModifier_Content<Self>
-    associatedtype Body : View
-    func body(content: Content) -> Self.Body
+  typealias Content = _ViewModifier_Content<Self>
+  associatedtype Body: View
+  func body(content: Content) -> Self.Body
 }
 
-public struct _ViewModifier_Content<Modifier> : View where Modifier : ViewModifier {
-    public let modifier: Modifier
-    public let view: AnyView
-    
-    public var body: Never {
-        neverBody("_ViewModifier_Content")
-    }
+public struct _ViewModifier_Content<Modifier>: View where Modifier: ViewModifier {
+  public let modifier: Modifier
+  public let view: AnyView
+
+  public var body: Never {
+    neverBody("_ViewModifier_Content")
+  }
 }
 
 public extension View {
-    func modifier<Modifier>(_ modifier: Modifier) -> Modifier.Body where Modifier: ViewModifier {
-        modifier.body(content: .init(modifier: modifier, view: AnyView(self)))
-    }
+  func modifier<Modifier>(_ modifier: Modifier) -> Modifier.Body where Modifier: ViewModifier {
+    modifier.body(content: .init(modifier: modifier, view: AnyView(self)))
+  }
 }

--- a/Sources/TokamakCore/Modifiers/ViewModifier.swift
+++ b/Sources/TokamakCore/Modifiers/ViewModifier.swift
@@ -12,28 +12,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import JavaScriptKit
-import TokamakDOM
+public protocol ViewModifier {
+    typealias Content = _ViewModifier_Content<Self>
+    associatedtype Body : View
+    func body(content: Content) -> Self.Body
+}
 
-let document = JSObjectRef.global.document.object!
-
-_ = document.head.object!.insertAdjacentHTML!("beforeend", #"""
-<link
-  rel="stylesheet"
-  href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css">
-"""#)
-
-let div = document.createElement!("div").object!
-let renderer = DOMRenderer(
-  VStack {
-    Counter(count: 5, limit: 7)
-    ZStack {
-      Text("I'm on bottom")
-      Text("I'm on top")
+public struct _ViewModifier_Content<Modifier> : View where Modifier : ViewModifier {
+    public let modifier: Modifier
+    public let view: AnyView
+    
+    public var body: Never {
+        neverBody("_ViewModifier_Content")
     }
-    SVGCircle()
-  },
-  div
-)
+}
 
-_ = document.body.object!.appendChild!(div)
+public extension View {
+    func modifier<Modifier>(_ modifier: Modifier) -> Modifier.Body where Modifier: ViewModifier {
+        modifier.body(content: .init(modifier: modifier, view: AnyView(self)))
+    }
+}

--- a/Sources/TokamakCore/Modifiers/zIndex.swift
+++ b/Sources/TokamakCore/Modifiers/zIndex.swift
@@ -12,20 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-public struct ZIndexModifier : ViewModifier {
-    public let index: Double
-    
-    public func body(content: Content) -> some View {
-        content
-    }
+public struct _ZIndexModifier: ViewModifier {
+  public let index: Double
+
+  public func body(content: Content) -> some View {
+    content
+  }
 }
 
 public extension View {
-    /// Controls the display order of overlapping views.
-    /// - Parameters:
-    ///     - value: A relative front-to-back ordering for this view; the default is 0.
-    func zIndex(_ value: Double = 0) -> some View {
-        self
-            .modifier(ZIndexModifier(index: value))
-    }
+  /// Controls the display order of overlapping views.
+  /// - Parameters:
+  ///     - value: A relative front-to-back ordering for this view; the default is 0.
+  func zIndex(_ value: Double = 0) -> some View {
+    modifier(_ZIndexModifier(index: value))
+  }
 }

--- a/Sources/TokamakCore/Modifiers/zIndex.swift
+++ b/Sources/TokamakCore/Modifiers/zIndex.swift
@@ -12,28 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import JavaScriptKit
-import TokamakDOM
-
-let document = JSObjectRef.global.document.object!
-
-_ = document.head.object!.insertAdjacentHTML!("beforeend", #"""
-<link
-  rel="stylesheet"
-  href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css">
-"""#)
-
-let div = document.createElement!("div").object!
-let renderer = DOMRenderer(
-  VStack {
-    Counter(count: 5, limit: 7)
-    ZStack {
-      Text("I'm on bottom")
-      Text("I'm on top")
+public struct ZIndexModifier : ViewModifier {
+    public let index: Double
+    
+    public func body(content: Content) -> some View {
+        content
     }
-    SVGCircle()
-  },
-  div
-)
+}
 
-_ = document.body.object!.appendChild!(div)
+public extension View {
+    /// Controls the display order of overlapping views.
+    /// - Parameters:
+    ///     - value: A relative front-to-back ordering for this view; the default is 0.
+    func zIndex(_ value: Double = 0) -> some View {
+        self
+            .modifier(ZIndexModifier(index: value))
+    }
+}

--- a/Sources/TokamakCore/Views/TupleView.swift
+++ b/Sources/TokamakCore/Views/TupleView.swift
@@ -29,6 +29,11 @@ public struct TupleView<T>: View {
     self.value = value
     children = []
   }
+  
+  public init(_ value: T, children: [AnyView]) {
+    self.value = value
+    self.children = children
+  }
 
   init<T1: View, T2: View>(_ v1: T1, _ v2: T2) where T == (T1, T2) {
     value = (v1, v2)

--- a/Sources/TokamakCore/Views/TupleView.swift
+++ b/Sources/TokamakCore/Views/TupleView.swift
@@ -29,7 +29,7 @@ public struct TupleView<T>: View {
     self.value = value
     children = []
   }
-  
+
   public init(_ value: T, children: [AnyView]) {
     self.value = value
     self.children = children

--- a/Sources/TokamakCore/Views/ZStack.swift
+++ b/Sources/TokamakCore/Views/ZStack.swift
@@ -1,0 +1,64 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/// An alignment in both axes.
+public struct Alignment: Equatable {
+  public var horizontal: HorizontalAlignment
+  public var vertical: VerticalAlignment
+  
+  public init(
+    horizontal: HorizontalAlignment,
+    vertical: VerticalAlignment
+  ) {
+    self.horizontal = horizontal
+    self.vertical = vertical
+  }
+  
+  public static let topLeading     = Self.init(horizontal: .leading, vertical: .top)
+  public static let top            = Self.init(horizontal: .center, vertical: .top)
+  public static let topTrailing    = Self.init(horizontal: .trailing, vertical: .top)
+  public static let leading        = Self.init(horizontal: .leading, vertical: .center)
+  public static let center         = Self.init(horizontal: .center, vertical: .center)
+  public static let trailing       = Self.init(horizontal: .trailing, vertical: .center)
+  public static let bottomLeading  = Self.init(horizontal: .leading, vertical: .bottom)
+  public static let bottom         = Self.init(horizontal: .center, vertical: .bottom)
+  public static let bottomTrailing = Self.init(horizontal: .trailing, vertical: .bottom)
+}
+
+/// A view that overlays its children, aligning them in both axes.
+public struct ZStack<Content>: View where Content: View {
+  public let alignment: Alignment
+  let spacing: CGFloat?
+  public let content: Content
+
+  public init(
+    alignment: Alignment = .center,
+    spacing: CGFloat? = nil,
+    @ViewBuilder content: () -> Content
+  ) {
+    self.alignment = alignment
+    self.spacing = spacing
+    self.content = content()
+  }
+
+  public var body: Never {
+    neverBody("ZStack")
+  }
+}
+
+extension ZStack: ParentView {
+  public var children: [AnyView] {
+    (content as? GroupView)?.children ?? [AnyView(content)]
+  }
+}

--- a/Sources/TokamakCore/Views/ZStack.swift
+++ b/Sources/TokamakCore/Views/ZStack.swift
@@ -16,7 +16,7 @@
 public struct Alignment: Equatable {
   public var horizontal: HorizontalAlignment
   public var vertical: VerticalAlignment
-  
+
   public init(
     horizontal: HorizontalAlignment,
     vertical: VerticalAlignment
@@ -24,16 +24,16 @@ public struct Alignment: Equatable {
     self.horizontal = horizontal
     self.vertical = vertical
   }
-  
-  public static let topLeading     = Self.init(horizontal: .leading, vertical: .top)
-  public static let top            = Self.init(horizontal: .center, vertical: .top)
-  public static let topTrailing    = Self.init(horizontal: .trailing, vertical: .top)
-  public static let leading        = Self.init(horizontal: .leading, vertical: .center)
-  public static let center         = Self.init(horizontal: .center, vertical: .center)
-  public static let trailing       = Self.init(horizontal: .trailing, vertical: .center)
-  public static let bottomLeading  = Self.init(horizontal: .leading, vertical: .bottom)
-  public static let bottom         = Self.init(horizontal: .center, vertical: .bottom)
-  public static let bottomTrailing = Self.init(horizontal: .trailing, vertical: .bottom)
+
+  public static let topLeading = Self(horizontal: .leading, vertical: .top)
+  public static let top = Self(horizontal: .center, vertical: .top)
+  public static let topTrailing = Self(horizontal: .trailing, vertical: .top)
+  public static let leading = Self(horizontal: .leading, vertical: .center)
+  public static let center = Self(horizontal: .center, vertical: .center)
+  public static let trailing = Self(horizontal: .trailing, vertical: .center)
+  public static let bottomLeading = Self(horizontal: .leading, vertical: .bottom)
+  public static let bottom = Self(horizontal: .center, vertical: .bottom)
+  public static let bottomTrailing = Self(horizontal: .trailing, vertical: .bottom)
 }
 
 /// A view that overlays its children, aligning them in both axes.

--- a/Sources/TokamakDOM/Modifiers/ModifiedContent.swift
+++ b/Sources/TokamakDOM/Modifiers/ModifiedContent.swift
@@ -12,28 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import JavaScriptKit
-import TokamakDOM
+import TokamakCore
+import Runtime
 
-let document = JSObjectRef.global.document.object!
+public typealias _ViewModifier_Content = TokamakCore._ViewModifier_Content
 
-_ = document.head.object!.insertAdjacentHTML!("beforeend", #"""
-<link
-  rel="stylesheet"
-  href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css">
-"""#)
-
-let div = document.createElement!("div").object!
-let renderer = DOMRenderer(
-  VStack {
-    Counter(count: 5, limit: 7)
-    ZStack {
-      Text("I'm on bottom")
-      Text("I'm on top")
-    }
-    SVGCircle()
-  },
-  div
-)
-
-_ = document.body.object!.appendChild!(div)
+extension _ViewModifier_Content: ViewDeferredToRenderer where Modifier: ViewModifier {
+  public var deferredBody: AnyView {
+    AnyView(HTML("div", modifier.attributes()) {
+      view
+    })
+  }
+}

--- a/Sources/TokamakDOM/Modifiers/ModifiedContent.swift
+++ b/Sources/TokamakDOM/Modifiers/ModifiedContent.swift
@@ -17,10 +17,16 @@ import Runtime
 
 public typealias _ViewModifier_Content = TokamakCore._ViewModifier_Content
 
-extension _ViewModifier_Content: ViewDeferredToRenderer where Modifier: ViewModifier {
+extension _ViewModifier_Content: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
-    AnyView(HTML("div", modifier.attributes()) {
-      view
-    })
+    if let domModifier = modifier as? DOMViewModifier {
+      return AnyView(HTML("div", domModifier.attributes()) {
+        view
+      })
+    } else {
+      return AnyView(HTML("div") {
+        view
+      })
+    }
   }
 }

--- a/Sources/TokamakDOM/Modifiers/ViewModifier.swift
+++ b/Sources/TokamakDOM/Modifiers/ViewModifier.swift
@@ -12,28 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import JavaScriptKit
-import TokamakDOM
+import TokamakCore
 
-let document = JSObjectRef.global.document.object!
+public protocol ViewModifier : TokamakCore.ViewModifier {
+  func attributes() -> [String:String]
+}
 
-_ = document.head.object!.insertAdjacentHTML!("beforeend", #"""
-<link
-  rel="stylesheet"
-  href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css">
-"""#)
-
-let div = document.createElement!("div").object!
-let renderer = DOMRenderer(
-  VStack {
-    Counter(count: 5, limit: 7)
-    ZStack {
-      Text("I'm on bottom")
-      Text("I'm on top")
-    }
-    SVGCircle()
-  },
-  div
-)
-
-_ = document.body.object!.appendChild!(div)
+extension ZIndexModifier : ViewModifier {
+  public func attributes() -> [String : String] {
+    ["style": "z-index: \(index);"]
+  }
+}

--- a/Sources/TokamakDOM/Modifiers/ViewModifier.swift
+++ b/Sources/TokamakDOM/Modifiers/ViewModifier.swift
@@ -14,11 +14,13 @@
 
 import TokamakCore
 
-public protocol ViewModifier : TokamakCore.ViewModifier {
+public typealias ViewModifier = TokamakCore.ViewModifier
+
+public protocol DOMViewModifier {
   func attributes() -> [String:String]
 }
 
-extension ZIndexModifier : ViewModifier {
+extension ZIndexModifier : DOMViewModifier {
   public func attributes() -> [String : String] {
     ["style": "z-index: \(index);"]
   }

--- a/Sources/TokamakDOM/Modifiers/ViewModifier.swift
+++ b/Sources/TokamakDOM/Modifiers/ViewModifier.swift
@@ -15,13 +15,27 @@
 import TokamakCore
 
 public typealias ViewModifier = TokamakCore.ViewModifier
+public typealias ModifiedContent = TokamakCore.ModifiedContent
 
 public protocol DOMViewModifier {
-  func attributes() -> [String:String]
+  var attributes: [String: String] { get }
 }
 
-extension ZIndexModifier : DOMViewModifier {
-  public func attributes() -> [String : String] {
+extension ModifiedContent: DOMViewModifier where Content: DOMViewModifier, Modifier: DOMViewModifier {
+  // Merge attributes
+  public var attributes: [String: String] {
+    var attr = content.attributes
+    for (key, val) in modifier.attributes {
+      if let prev = attr[key] {
+        attr[key] = prev + val
+      }
+    }
+    return attr
+  }
+}
+
+extension _ZIndexModifier: DOMViewModifier {
+  public var attributes: [String: String] {
     ["style": "z-index: \(index);"]
   }
 }

--- a/Sources/TokamakDOM/Modifiers/_ViewModifier_Content.swift
+++ b/Sources/TokamakDOM/Modifiers/_ViewModifier_Content.swift
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import TokamakCore
 import Runtime
+import TokamakCore
 
 public typealias _ViewModifier_Content = TokamakCore._ViewModifier_Content
 
 extension _ViewModifier_Content: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
     if let domModifier = modifier as? DOMViewModifier {
-      return AnyView(HTML("div", domModifier.attributes()) {
+      return AnyView(HTML("div", domModifier.attributes) {
         view
       })
     } else {

--- a/Sources/TokamakDOM/Views/ZStack.swift
+++ b/Sources/TokamakDOM/Views/ZStack.swift
@@ -29,11 +29,9 @@ extension VerticalAlignment {
   }
 }
 
-struct _ZStack_ContentGridItem : ViewModifier, DOMViewModifier {
-  func attributes() -> [String : String] {
-    ["style": "grid-area: a;"]
-  }
-  
+struct _ZStack_ContentGridItem: ViewModifier, DOMViewModifier {
+  let attributes = ["style": "grid-area: a;"]
+
   func body(content: Content) -> some View {
     content
   }
@@ -42,7 +40,13 @@ struct _ZStack_ContentGridItem : ViewModifier, DOMViewModifier {
 extension ZStack: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
     AnyView(HTML("div", [
-      "style": "display: grid; grid-template-columns: 1fr; width: fit-content; justify-items: \(alignment.horizontal.cssValue); align-items: \(alignment.vertical.cssValue)"
+      "style": """
+      display: grid;
+      grid-template-columns: 1fr;
+      width: fit-content;
+      justify-items: \(alignment.horizontal.cssValue);
+      align-items: \(alignment.vertical.cssValue)
+      """,
     ]) {
       TupleView(children, children: children.map { AnyView($0.modifier(_ZStack_ContentGridItem())) })
     })

--- a/Sources/TokamakDOM/Views/ZStack.swift
+++ b/Sources/TokamakDOM/Views/ZStack.swift
@@ -1,0 +1,50 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import TokamakCore
+
+public typealias ZStack = TokamakCore.ZStack
+
+extension VerticalAlignment {
+  var cssValue: String {
+    switch self {
+    case .top:
+      return "start"
+    case .center:
+      return "center"
+    case .bottom:
+      return "end"
+    }
+  }
+}
+
+struct _ZStack_ContentGridItem : ViewModifier {
+  func attributes() -> [String : String] {
+    ["style": "grid-area: a;"]
+  }
+  
+  func body(content: Content) -> some View {
+    content
+  }
+}
+
+extension ZStack: ViewDeferredToRenderer {
+  public var deferredBody: AnyView {
+    AnyView(HTML("div", [
+      "style": "display: grid; grid-template-columns: 1fr; width: fit-content; justify-items: \(alignment.horizontal.cssValue); align-items: \(alignment.vertical.cssValue)"
+    ]) {
+      TupleView(children, children: children.map { AnyView($0.modifier(_ZStack_ContentGridItem())) })
+    })
+  }
+}

--- a/Sources/TokamakDOM/Views/ZStack.swift
+++ b/Sources/TokamakDOM/Views/ZStack.swift
@@ -29,7 +29,7 @@ extension VerticalAlignment {
   }
 }
 
-struct _ZStack_ContentGridItem : ViewModifier {
+struct _ZStack_ContentGridItem : ViewModifier, DOMViewModifier {
   func attributes() -> [String : String] {
     ["style": "grid-area: a;"]
   }

--- a/Sources/TokamakDemo/main.swift
+++ b/Sources/TokamakDemo/main.swift
@@ -23,7 +23,7 @@ _ = document.head.object!.insertAdjacentHTML!("beforeend", #"""
   href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css">
 """#)
 
-struct CustomModifier : ViewModifier {
+struct CustomModifier: ViewModifier {
   func body(content: Content) -> some View {
     Text("Whole new body!")
   }
@@ -35,6 +35,8 @@ let renderer = DOMRenderer(
     Counter(count: 5, limit: 7)
     ZStack {
       Text("I'm on bottom")
+      Text("I'm forced to the top")
+        .zIndex(1)
       Text("I'm on top")
     }
     Text("This is the inital text")

--- a/Sources/TokamakDemo/main.swift
+++ b/Sources/TokamakDemo/main.swift
@@ -23,6 +23,12 @@ _ = document.head.object!.insertAdjacentHTML!("beforeend", #"""
   href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.4.1/semantic.min.css">
 """#)
 
+struct CustomModifier : ViewModifier {
+  func body(content: Content) -> some View {
+    Text("Whole new body!")
+  }
+}
+
 let div = document.createElement!("div").object!
 let renderer = DOMRenderer(
   VStack {
@@ -31,6 +37,8 @@ let renderer = DOMRenderer(
       Text("I'm on bottom")
       Text("I'm on top")
     }
+    Text("This is the inital text")
+      .modifier(CustomModifier())
     SVGCircle()
   },
   div


### PR DESCRIPTION
Resolved #111.

I created ZStack using CSS grid.

To support changing the `zIndex` I created support for `ViewModifiers`. zIndex currently isn't working due to the order in which the `_ZStack_ContentGridItem` and `ZIndexModifier` modifiers are applied.

If you have a different approach to setting the z-index or creating modifiers, I can switch this over to that.