### PR TITLE
Fix HStack divs without flexbox

### DIFF
--- a/Sources/TokamakCore/Views/HStack.swift
+++ b/Sources/TokamakCore/Views/HStack.swift
@@ -22,8 +22,8 @@ public enum VerticalAlignment: Equatable {
 }
 
 public struct HStack<Content>: View where Content: View {
-  let alignment: VerticalAlignment
-  let spacing: CGFloat?
+  public let alignment: VerticalAlignment
+  public let spacing: CGFloat?
   public let content: Content
 
   public init(

--- a/Sources/TokamakCore/Views/VStack.swift
+++ b/Sources/TokamakCore/Views/VStack.swift
@@ -20,7 +20,7 @@ public enum HorizontalAlignment: Equatable {
 
 public struct VStack<Content>: View where Content: View {
   public let alignment: HorizontalAlignment
-  let spacing: CGFloat?
+  public let spacing: CGFloat?
   public let content: Content
 
   public init(

--- a/Sources/TokamakCore/Views/ZStack.swift
+++ b/Sources/TokamakCore/Views/ZStack.swift
@@ -39,7 +39,7 @@ public struct Alignment: Equatable {
 /// A view that overlays its children, aligning them in both axes.
 public struct ZStack<Content>: View where Content: View {
   public let alignment: Alignment
-  let spacing: CGFloat?
+  public let spacing: CGFloat?
   public let content: Content
 
   public init(

--- a/Sources/TokamakDOM/Views/HStack.swift
+++ b/Sources/TokamakDOM/Views/HStack.swift
@@ -16,8 +16,23 @@ import TokamakCore
 
 public typealias HStack = TokamakCore.HStack
 
+extension VerticalAlignment {
+  var cssValue: String {
+    switch self {
+    case .top:
+      return "start"
+    case .center:
+      return "center"
+    case .bottom:
+      return "end"
+    }
+  }
+}
+
 extension HStack: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
-    AnyView(HTML("div") { content })
+    AnyView(HTML("div", [
+      "style": "display: flex; flex-direction: row; align-items: \(alignment.cssValue);",
+    ]) { content })
   }
 }

--- a/Sources/TokamakDOM/Views/ZStack.swift
+++ b/Sources/TokamakDOM/Views/ZStack.swift
@@ -16,19 +16,6 @@ import TokamakCore
 
 public typealias ZStack = TokamakCore.ZStack
 
-extension VerticalAlignment {
-  var cssValue: String {
-    switch self {
-    case .top:
-      return "start"
-    case .center:
-      return "center"
-    case .bottom:
-      return "end"
-    }
-  }
-}
-
 struct _ZStack_ContentGridItem: ViewModifier, DOMViewModifier {
   let attributes = ["style": "grid-area: a;"]
 


### PR DESCRIPTION
`HStack` previously had no styles, and was thus creating divs without flex box styling.