### PR TITLE
Update DOM node properties and listeners on renderer update

### DIFF
--- a/Sources/TokamakDOM/Views/HTML.swift
+++ b/Sources/TokamakDOM/Views/HTML.swift
@@ -91,7 +91,7 @@ extension HTML where Content == EmptyView {
     _ attributes: [String: String] = [:],
     listeners: [String: Listener] = [:]
   ) {
-    self = HTML(tag, attributes) { EmptyView() }
+    self = HTML(tag, attributes, listeners: listeners) { EmptyView() }
   }
 }
 

--- a/Sources/TokamakDOM/Views/HTML.swift
+++ b/Sources/TokamakDOM/Views/HTML.swift
@@ -42,10 +42,21 @@ extension AnyHTML {
     """
   }
 
-  func update(dom: JSObjectRef) {
-    // FIXME: handle attributes and listeners here
+  func update(dom: DOMNode) {
+    // FIXME: is there a sensible way to diff attributes and listeners to avoid
+    // crossing the JavaScript bridge and touching DOM if not needed?
+
+    // @carson-katri: For diffing, could you build a Set from the keys and values of the dictionary,
+    // then use the standard lib to get the difference?
+
+    for (attribute, value) in attributes {
+      _ = dom.ref[dynamicMember: attribute] = JSValue(stringLiteral: value)
+    }
+
+    dom.reinstall(listeners)
+
     guard let innerHTML = innerHTML else { return }
-    dom.innerHTML = .string(innerHTML)
+    dom.ref.innerHTML = .string(innerHTML)
   }
 }
 
@@ -80,10 +91,7 @@ extension HTML where Content == EmptyView {
     _ attributes: [String: String] = [:],
     listeners: [String: Listener] = [:]
   ) {
-    self.tag = tag
-    self.attributes = attributes
-    self.listeners = listeners
-    content = EmptyView()
+    self = HTML(tag, attributes) { EmptyView() }
   }
 }
 


### PR DESCRIPTION
This fixes an issue discovered in #116 by updating DOM attributes when `AnyHTML.update(dom:)` is called from the renderer update function. I'm still looking for a good solution for reinstalling all event listeners correctly in the same function, all suggestions welcome. 