### PR TITLE
Check whether PRs have labels with GitHub Actions

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -6,7 +6,7 @@ name: Check PR labels
 # events but only for the master branch
 on:
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -1,0 +1,29 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Check PR labels
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  pull_request:
+    branches: [ master ]
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  check-labels:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Match PR Label
+      uses: zwaldowski/match-label-action@v2
+      with:
+        allowed_multiple: >
+          API design,
+          bug,
+          continuous integration,
+          dependencies,
+          documentation,
+          enhancement,
+          SwiftUI compatibility,


### PR DESCRIPTION
To improve housekeeping, this workflow checks that all PRs have labels on them.