### PR TITLE
Use proxy types for package private properties

### DIFF
--- a/Sources/TokamakCore/Views/Button.swift
+++ b/Sources/TokamakCore/Views/Button.swift
@@ -45,6 +45,11 @@ extension Button: ParentView {
   }
 }
 
-public func buttonLabel(_ button: Button<Text>) -> String {
-  button.label.content
+/// This is a helper class that works around absence of "package private" access control in Swift
+public struct _ButtonProxy {
+  public let subject: Button<Text>
+
+  public init(_ subject: Button<Text>) { self.subject = subject }
+
+  public var label: _TextProxy { _TextProxy(subject.label) }
 }

--- a/Sources/TokamakCore/Views/Button.swift
+++ b/Sources/TokamakCore/Views/Button.swift
@@ -18,8 +18,7 @@
 public struct Button<Label>: View where Label: View {
   let label: Label
 
-  // FIXME: this should be internal
-  public let action: () -> ()
+  let action: () -> ()
 
   public init(action: @escaping () -> (), @ViewBuilder label: () -> Label) {
     self.label = label()
@@ -52,4 +51,5 @@ public struct _ButtonProxy {
   public init(_ subject: Button<Text>) { self.subject = subject }
 
   public var label: _TextProxy { _TextProxy(subject.label) }
+  public var action: () -> () { subject.action }
 }

--- a/Sources/TokamakCore/Views/SecureField.swift
+++ b/Sources/TokamakCore/Views/SecureField.swift
@@ -17,10 +17,8 @@
 
 public struct SecureField<Label>: View where Label: View {
   let label: Label
-
-  // FIXME: this should be internal
-  public let textBinding: Binding<String>
-  public let commitAction: () -> ()
+  let textBinding: Binding<String>
+  let onCommit: () -> ()
 
   public var body: Never {
     neverBody("SecureField")
@@ -34,7 +32,7 @@ extension SecureField where Label == Text {
   ) where S: StringProtocol {
     label = Text(title)
     textBinding = text.projectedValue
-    commitAction = onCommit
+    self.onCommit = onCommit
   }
 }
 
@@ -45,4 +43,6 @@ public struct _SecureFieldProxy {
   public init(_ subject: SecureField<Text>) { self.subject = subject }
 
   public var label: _TextProxy { _TextProxy(subject.label) }
+  public var textBinding: Binding<String> { subject.textBinding }
+  public var onCommit: () -> () { subject.onCommit }
 }

--- a/Sources/TokamakCore/Views/SecureField.swift
+++ b/Sources/TokamakCore/Views/SecureField.swift
@@ -38,6 +38,11 @@ extension SecureField where Label == Text {
   }
 }
 
-public func secureFieldLabel(_ secureField: SecureField<Text>) -> String {
-  secureField.label.content
+/// This is a helper class that works around absence of "package private" access control in Swift
+public struct _SecureFieldProxy {
+  public let subject: SecureField<Text>
+
+  public init(_ subject: SecureField<Text>) { self.subject = subject }
+
+  public var label: _TextProxy { _TextProxy(subject.label) }
 }

--- a/Sources/TokamakCore/Views/Text.swift
+++ b/Sources/TokamakCore/Views/Text.swift
@@ -50,8 +50,13 @@ public struct Text: View {
   }
 }
 
-public func textContent(_ text: Text) -> String {
-  text.content
+/// This is a helper class that works around absence of "package private" access control in Swift
+public struct _TextProxy {
+  public let subject: Text
+
+  public init(_ subject: Text) { self.subject = subject }
+
+  public var content: String { subject.content }
 }
 
 public extension Text {

--- a/Sources/TokamakCore/Views/TextField.swift
+++ b/Sources/TokamakCore/Views/TextField.swift
@@ -48,6 +48,11 @@ extension TextField where Label == Text {
   // ) where S : StringProtocol
 }
 
-public func textFieldLabel(_ textField: TextField<Text>) -> String {
-  textField.label.content
+/// This is a helper class that works around absence of "package private" access control in Swift
+public struct _TextFieldProxy {
+  public let subject: TextField<Text>
+
+  public init(_ subject: TextField<Text>) { self.subject = subject }
+
+  public var label: _TextProxy { _TextProxy(subject.label) }
 }

--- a/Sources/TokamakCore/Views/TextField.swift
+++ b/Sources/TokamakCore/Views/TextField.swift
@@ -17,11 +17,9 @@
 
 public struct TextField<Label>: View where Label: View {
   let label: Label
-
-  // FIXME: this should be internal
-  public let textBinding: Binding<String>
-  public let editingChangedAction: (Bool) -> ()
-  public let commitAction: () -> ()
+  let textBinding: Binding<String>
+  let onEditingChanged: (Bool) -> ()
+  let onCommit: () -> ()
 
   public var body: Never {
     neverBody("TextField")
@@ -36,8 +34,8 @@ extension TextField where Label == Text {
   ) where S: StringProtocol {
     label = Text(title)
     textBinding = text.projectedValue
-    editingChangedAction = onEditingChanged
-    commitAction = onCommit
+    self.onEditingChanged = onEditingChanged
+    self.onCommit = onCommit
   }
 
   // FIXME: implement this method, which uses a Formatter to control the value of the TextField
@@ -55,4 +53,7 @@ public struct _TextFieldProxy {
   public init(_ subject: TextField<Text>) { self.subject = subject }
 
   public var label: _TextProxy { _TextProxy(subject.label) }
+  public var textBinding: Binding<String> { subject.textBinding }
+  public var onCommit: () -> () { subject.onCommit }
+  public var onEditingChanged: (Bool) -> () { subject.onEditingChanged }
 }

--- a/Sources/TokamakCore/Views/TupleView.swift
+++ b/Sources/TokamakCore/Views/TupleView.swift
@@ -22,65 +22,66 @@ public struct TupleView<T>: View {
 
   public let value: T
 
-  // FIXME: should not be public
-  public let children: [AnyView]
+  let _children: [AnyView]
 
   public init(_ value: T) {
     self.value = value
-    children = []
+    _children = []
   }
 
   public init(_ value: T, children: [AnyView]) {
     self.value = value
-    self.children = children
+    _children = children
   }
 
   init<T1: View, T2: View>(_ v1: T1, _ v2: T2) where T == (T1, T2) {
     value = (v1, v2)
-    children = [AnyView(v1), AnyView(v2)]
+    _children = [AnyView(v1), AnyView(v2)]
   }
 
   init<T1: View, T2: View, T3: View>(_ v1: T1, _ v2: T2, _ v3: T3) where T == (T1, T2, T3) {
     value = (v1, v2, v3)
-    children = [AnyView(v1), AnyView(v2), AnyView(v3)]
+    _children = [AnyView(v1), AnyView(v2), AnyView(v3)]
   }
 
   // swiftlint:disable line_length
   // swiftlint:disable large_tuple
   init<T1: View, T2: View, T3: View, T4: View>(_ v1: T1, _ v2: T2, _ v3: T3, _ v4: T4) where T == (T1, T2, T3, T4) {
     value = (v1, v2, v3, v4)
-    children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4)]
+    _children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4)]
   }
 
   init<T1: View, T2: View, T3: View, T4: View, T5: View>(_ v1: T1, _ v2: T2, _ v3: T3, _ v4: T4, _ v5: T5) where T == (T1, T2, T3, T4, T5) {
     value = (v1, v2, v3, v4, v5)
-    children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5)]
+    _children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5)]
   }
 
   init<T1: View, T2: View, T3: View, T4: View, T5: View, T6: View>(_ v1: T1, _ v2: T2, _ v3: T3, _ v4: T4, _ v5: T5, _ v6: T6) where T == (T1, T2, T3, T4, T5, T6) {
     value = (v1, v2, v3, v4, v5, v6)
-    children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5), AnyView(v6)]
+    _children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5), AnyView(v6)]
   }
 
   init<T1: View, T2: View, T3: View, T4: View, T5: View, T6: View, T7: View>(_ v1: T1, _ v2: T2, _ v3: T3, _ v4: T4, _ v5: T5, _ v6: T6, _ v7: T7) where T == (T1, T2, T3, T4, T5, T6, T7) {
     value = (v1, v2, v3, v4, v5, v6, v7)
-    children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5), AnyView(v6), AnyView(v7)]
+    _children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5), AnyView(v6), AnyView(v7)]
   }
 
   init<T1: View, T2: View, T3: View, T4: View, T5: View, T6: View, T7: View, T8: View>(_ v1: T1, _ v2: T2, _ v3: T3, _ v4: T4, _ v5: T5, _ v6: T6, _ v7: T7, _ v8: T8) where T == (T1, T2, T3, T4, T5, T6, T7, T8) {
     value = (v1, v2, v3, v4, v5, v6, v7, v8)
-    children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5), AnyView(v6), AnyView(v7), AnyView(v8)]
+    _children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5), AnyView(v6), AnyView(v7), AnyView(v8)]
   }
 
   init<T1: View, T2: View, T3: View, T4: View, T5: View, T6: View, T7: View, T8: View, T9: View>(_ v1: T1, _ v2: T2, _ v3: T3, _ v4: T4, _ v5: T5, _ v6: T6, _ v7: T7, _ v8: T8, _ v9: T9) where T == (T1, T2, T3, T4, T5, T6, T7, T8, T9) {
     value = (v1, v2, v3, v4, v5, v6, v7, v8, v9)
-    children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5), AnyView(v6), AnyView(v7), AnyView(v8), AnyView(v9)]
+    _children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5), AnyView(v6), AnyView(v7), AnyView(v8), AnyView(v9)]
   }
 
   init<T1: View, T2: View, T3: View, T4: View, T5: View, T6: View, T7: View, T8: View, T9: View, T10: View>(_ v1: T1, _ v2: T2, _ v3: T3, _ v4: T4, _ v5: T5, _ v6: T6, _ v7: T7, _ v8: T8, _ v9: T9, _ v10: T10) where T == (T1, T2, T3, T4, T5, T6, T7, T8, T9, T10) {
     value = (v1, v2, v3, v4, v5, v6, v7, v8, v9, v10)
-    children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5), AnyView(v6), AnyView(v7), AnyView(v8), AnyView(v9), AnyView(v10)]
+    _children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4), AnyView(v5), AnyView(v6), AnyView(v7), AnyView(v8), AnyView(v9), AnyView(v10)]
   }
 }
 
-extension TupleView: GroupView {}
+extension TupleView: GroupView {
+  public var children: [AnyView] { _children }
+}

--- a/Sources/TokamakCore/Views/TupleView.swift
+++ b/Sources/TokamakCore/Views/TupleView.swift
@@ -39,13 +39,13 @@ public struct TupleView<T>: View {
     _children = [AnyView(v1), AnyView(v2)]
   }
 
+  // swiftlint:disable large_tuple
   init<T1: View, T2: View, T3: View>(_ v1: T1, _ v2: T2, _ v3: T3) where T == (T1, T2, T3) {
     value = (v1, v2, v3)
     _children = [AnyView(v1), AnyView(v2), AnyView(v3)]
   }
 
   // swiftlint:disable line_length
-  // swiftlint:disable large_tuple
   init<T1: View, T2: View, T3: View, T4: View>(_ v1: T1, _ v2: T2, _ v3: T3, _ v4: T4) where T == (T1, T2, T3, T4) {
     value = (v1, v2, v3, v4)
     _children = [AnyView(v1), AnyView(v2), AnyView(v3), AnyView(v4)]

--- a/Sources/TokamakDOM/Views/Button.swift
+++ b/Sources/TokamakDOM/Views/Button.swift
@@ -21,7 +21,7 @@ public typealias Button = TokamakCore.Button
 
 extension Button: ViewDeferredToRenderer where Label == Text {
   public var deferredBody: AnyView {
-    AnyView(HTML("button", listeners: ["click": { _ in action() }]) {
+    AnyView(HTML("button", listeners: ["click": { _ in _ButtonProxy(self).action() }]) {
       _ButtonProxy(self).label.subject
     })
   }

--- a/Sources/TokamakDOM/Views/Button.swift
+++ b/Sources/TokamakDOM/Views/Button.swift
@@ -21,7 +21,7 @@ public typealias Button = TokamakCore.Button
 
 extension Button: ViewDeferredToRenderer where Label == Text {
   public var deferredBody: AnyView {
-    AnyView(HTML("button", listeners: ["click": _ButtonProxy(self).action]) {
+    AnyView(HTML("button", listeners: ["click": { _ in _ButtonProxy(self).action() }]) {
       _ButtonProxy(self).label.subject
     })
   }

--- a/Sources/TokamakDOM/Views/Button.swift
+++ b/Sources/TokamakDOM/Views/Button.swift
@@ -21,7 +21,7 @@ public typealias Button = TokamakCore.Button
 
 extension Button: ViewDeferredToRenderer where Label == Text {
   public var deferredBody: AnyView {
-    AnyView(HTML("button", listeners: ["click": { _ in _ButtonProxy(self).action() }]) {
+    AnyView(HTML("button", listeners: ["click": _ButtonProxy(self).action]) {
       _ButtonProxy(self).label.subject
     })
   }

--- a/Sources/TokamakDOM/Views/Button.swift
+++ b/Sources/TokamakDOM/Views/Button.swift
@@ -22,7 +22,7 @@ public typealias Button = TokamakCore.Button
 extension Button: ViewDeferredToRenderer where Label == Text {
   public var deferredBody: AnyView {
     AnyView(HTML("button", listeners: ["click": { _ in action() }]) {
-      Text(buttonLabel(self))
+      _ButtonProxy(self).label.subject
     })
   }
 }

--- a/Sources/TokamakDOM/Views/SecureField.swift
+++ b/Sources/TokamakDOM/Views/SecureField.swift
@@ -24,7 +24,7 @@ extension SecureField: ViewDeferredToRenderer where Label == Text {
     AnyView(HTML("input", [
       "type": "password",
       "value": textBinding.wrappedValue,
-      "placeholder": secureFieldLabel(self),
+      "placeholder": _SecureFieldProxy(self).label.content,
     ], listeners: [
       "keypress": { event in if event.key == "Enter" { commitAction() } },
       "input": { event in

--- a/Sources/TokamakDOM/Views/SecureField.swift
+++ b/Sources/TokamakDOM/Views/SecureField.swift
@@ -21,15 +21,16 @@ public typealias SecureField = TokamakCore.SecureField
 
 extension SecureField: ViewDeferredToRenderer where Label == Text {
   public var deferredBody: AnyView {
-    AnyView(HTML("input", [
+    let proxy = _SecureFieldProxy(self)
+    return AnyView(HTML("input", [
       "type": "password",
-      "value": textBinding.wrappedValue,
-      "placeholder": _SecureFieldProxy(self).label.content,
+      "value": proxy.textBinding.wrappedValue,
+      "placeholder": proxy.label.content,
     ], listeners: [
-      "keypress": { event in if event.key == "Enter" { commitAction() } },
+      "keypress": { event in if event.key == "Enter" { proxy.onCommit() } },
       "input": { event in
           if let newValue = event.target.object?.value.string {
-            textBinding.wrappedValue = newValue
+            proxy.textBinding.wrappedValue = newValue
           }
         },
     ]))

--- a/Sources/TokamakDOM/Views/Text.swift
+++ b/Sources/TokamakDOM/Views/Text.swift
@@ -146,7 +146,8 @@ extension Text: AnyHTML {
       letter-spacing: \(kerning);
       vertical-align: \(baseline == nil ? "baseline" : "\(baseline!)em");
       text-decoration: \(textDecoration);
-      text-decoration-color: \(strikethrough?.1?.description ?? underline?.1?.description ?? "inherit")
+      text-decoration-color: \(strikethrough?.1?.description ?? underline?.1?.description
+        ?? "inherit")
       """,
     ]
   }

--- a/Sources/TokamakDOM/Views/Text.swift
+++ b/Sources/TokamakDOM/Views/Text.swift
@@ -93,7 +93,7 @@ extension Font: StylesConvertible {
 }
 
 extension Text: AnyHTML {
-  public var innerHTML: String? { textContent(self) }
+  public var innerHTML: String? { _TextProxy(self).content }
   var tag: String { "span" }
   var attributes: [String: String] {
     var font: Font?

--- a/Sources/TokamakDOM/Views/TextField.swift
+++ b/Sources/TokamakDOM/Views/TextField.swift
@@ -24,7 +24,7 @@ extension TextField: ViewDeferredToRenderer where Label == Text {
     AnyView(HTML("input", [
       "type": "text",
       "value": textBinding.wrappedValue,
-      "placeholder": textFieldLabel(self),
+      "placeholder": _TextFieldProxy(self).label.content,
     ], listeners: [
       "focus": { _ in editingChangedAction(true) },
       "blur": { _ in editingChangedAction(false) },

--- a/Sources/TokamakDOM/Views/TextField.swift
+++ b/Sources/TokamakDOM/Views/TextField.swift
@@ -21,17 +21,19 @@ public typealias TextField = TokamakCore.TextField
 
 extension TextField: ViewDeferredToRenderer where Label == Text {
   public var deferredBody: AnyView {
-    AnyView(HTML("input", [
+    let proxy = _TextFieldProxy(self)
+
+    return AnyView(HTML("input", [
       "type": "text",
-      "value": textBinding.wrappedValue,
-      "placeholder": _TextFieldProxy(self).label.content,
+      "value": proxy.textBinding.wrappedValue,
+      "placeholder": proxy.label.content,
     ], listeners: [
-      "focus": { _ in editingChangedAction(true) },
-      "blur": { _ in editingChangedAction(false) },
-      "keypress": { event in if event.key == "Enter" { commitAction() } },
+      "focus": { _ in proxy.onEditingChanged(true) },
+      "blur": { _ in proxy.onEditingChanged(false) },
+      "keypress": { event in if event.key == "Enter" { proxy.onCommit() } },
       "input": { event in
           if let newValue = event.target.object?.value.string {
-            textBinding.wrappedValue = newValue
+            proxy.textBinding.wrappedValue = newValue
           }
         },
     ]))


### PR DESCRIPTION
I think that while public functions giving access to private properties does the job, they pollute the global namespace of `TokamakCore`, while for every property you need to create a separate function. These functions read a bit weird at their place of use, so I'm wondering whether the Proxy pattern could work better here. While it's more verbose, I find it a bit more readable, while also adding some sort of structure here for grouping multiple properties if needed.

CC @j-f1, this is something you might want to use in #125.