### PR TITLE
Add AppearanceActionModifier, onAppear/onDisappear

### DIFF
--- a/Sources/TokamakCore/Modifiers/AppearanceActionModifier.swift
+++ b/Sources/TokamakCore/Modifiers/AppearanceActionModifier.swift
@@ -1,0 +1,45 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+protocol AppearanceActionProtocol {
+  var appear: (() -> ())? { get }
+  var disappear: (() -> ())? { get }
+}
+
+struct _AppearanceActionModifier: ViewModifier {
+  var appear: (() -> ())?
+  var disappear: (() -> ())?
+  init(appear: (() -> ())? = nil, disappear: (() -> ())? = nil) {
+    self.appear = appear
+    self.disappear = disappear
+  }
+
+  typealias Body = Never
+}
+
+extension ModifiedContent: AppearanceActionProtocol
+  where Content: View, Modifier == _AppearanceActionModifier {
+  var appear: (() -> ())? { modifier.appear }
+  var disappear: (() -> ())? { modifier.disappear }
+}
+
+extension View {
+  public func onAppear(perform action: (() -> Swift.Void)? = nil) -> some View {
+    modifier(_AppearanceActionModifier(appear: action, disappear: nil))
+  }
+
+  public func onDisappear(perform action: (() -> Swift.Void)? = nil) -> some View {
+    modifier(_AppearanceActionModifier(appear: nil, disappear: action))
+  }
+}

--- a/Sources/TokamakCore/Modifiers/AppearanceActionModifier.swift
+++ b/Sources/TokamakCore/Modifiers/AppearanceActionModifier.swift
@@ -17,6 +17,7 @@ protocol AppearanceActionProtocol {
   var disappear: (() -> ())? { get }
 }
 
+/// Underscore is present in the name for SwiftUI compatibility.
 struct _AppearanceActionModifier: ViewModifier {
   var appear: (() -> ())?
   var disappear: (() -> ())?

--- a/Sources/TokamakCore/Modifiers/AppearanceActionModifier.swift
+++ b/Sources/TokamakCore/Modifiers/AppearanceActionModifier.swift
@@ -37,10 +37,10 @@ extension ModifiedContent: AppearanceActionProtocol
 
 extension View {
   public func onAppear(perform action: (() -> Swift.Void)? = nil) -> some View {
-    modifier(_AppearanceActionModifier(appear: action, disappear: nil))
+    modifier(_AppearanceActionModifier(appear: action))
   }
 
   public func onDisappear(perform action: (() -> Swift.Void)? = nil) -> some View {
-    modifier(_AppearanceActionModifier(appear: nil, disappear: action))
+    modifier(_AppearanceActionModifier(disappear: action))
   }
 }

--- a/Sources/TokamakCore/Modifiers/AppearanceActionModifier.swift
+++ b/Sources/TokamakCore/Modifiers/AppearanceActionModifier.swift
@@ -36,11 +36,11 @@ extension ModifiedContent: AppearanceActionProtocol
 }
 
 extension View {
-  public func onAppear(perform action: (() -> Swift.Void)? = nil) -> some View {
+  public func onAppear(perform action: (() -> ())? = nil) -> some View {
     modifier(_AppearanceActionModifier(appear: action))
   }
 
-  public func onDisappear(perform action: (() -> Swift.Void)? = nil) -> some View {
+  public func onDisappear(perform action: (() -> ())? = nil) -> some View {
     modifier(_AppearanceActionModifier(disappear: action))
   }
 }

--- a/Sources/TokamakCore/Modifiers/ViewModifier.swift
+++ b/Sources/TokamakCore/Modifiers/ViewModifier.swift
@@ -28,8 +28,8 @@ public struct _ViewModifier_Content<Modifier>: View where Modifier: ViewModifier
 }
 
 public extension View {
-  func modifier<Modifier>(_ modifier: Modifier) -> Modifier.Body where Modifier: ViewModifier {
-    modifier.body(content: .init(modifier: modifier, view: AnyView(self)))
+  func modifier<Modifier>(_ modifier: Modifier) -> ModifiedContent<Self, Modifier> {
+    .init(content: self, modifier: modifier)
   }
 }
 

--- a/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
@@ -44,6 +44,10 @@ final class MountedCompositeView<R: Renderer>: MountedView<R>, Hashable {
   override func mount(with reconciler: StackReconciler<R>) {
     let childBody = reconciler.render(compositeView: self)
 
+    if let appearanceAction = view.view as? AppearanceActionProtocol {
+      appearanceAction.appear?()
+    }
+
     let child: MountedView<R> = childBody.makeMountedView(parentTarget,
                                                           environmentValues)
     mountedChildren = [child]
@@ -52,6 +56,10 @@ final class MountedCompositeView<R: Renderer>: MountedView<R>, Hashable {
 
   override func unmount(with reconciler: StackReconciler<R>) {
     mountedChildren.forEach { $0.unmount(with: reconciler) }
+
+    if let appearanceAction = view.view as? AppearanceActionProtocol {
+      appearanceAction.disappear?()
+    }
   }
 
   override func update(with reconciler: StackReconciler<R>) {

--- a/Sources/TokamakDOM/Modifiers/_ViewModifier_Content.swift
+++ b/Sources/TokamakDOM/Modifiers/_ViewModifier_Content.swift
@@ -15,17 +15,15 @@
 import Runtime
 import TokamakCore
 
-public typealias _ViewModifier_Content = TokamakCore._ViewModifier_Content
-
-extension _ViewModifier_Content: ViewDeferredToRenderer {
+extension ModifiedContent: ViewDeferredToRenderer where Content: View {
   public var deferredBody: AnyView {
     if let domModifier = modifier as? DOMViewModifier {
       return AnyView(HTML("div", domModifier.attributes) {
-        view
+        content
       })
     } else {
       return AnyView(HTML("div") {
-        view
+        content
       })
     }
   }

--- a/Sources/TokamakDemo/Counter.swift
+++ b/Sources/TokamakDemo/Counter.swift
@@ -29,6 +29,8 @@ public struct Counter: View {
           Button("Increment") { count += 1 }
           Text("\(count)")
         }
+        .onAppear { print("Counter.VStack onAppear") }
+        .onDisappear { print("Counter.VStack onDisappear") }
       ) : AnyView(
         VStack { Text("Limit exceeded") }
       )


### PR DESCRIPTION
This is required to unblock #136 as I think it would make sense for the `DOMEnvironment` view there to add/remove its color scheme listener in `onAppear`/`onDisappear` closures.

I've also restored full SwiftUI compatibility in the signature of `func modifier<Modifier>(_ modifier: Modifier)`. Consequently `ViewDeferredToRenderer` had to be implemented on `ModifiedContent` then instead of `_ViewModifier_Content` to make it work.