### PR TITLE
Use a range instead of an array in ForEach

### DIFF
--- a/Sources/TokamakCore/Views/ForEach.swift
+++ b/Sources/TokamakCore/Views/ForEach.swift
@@ -55,12 +55,12 @@ public extension ForEach where Data.Element: Identifiable, ID == Data.Element.ID
   }
 }
 
-public extension ForEach where Data == [Int], ID == Int {
+public extension ForEach where Data == Range<Int>, ID == Int {
   init(
     _ data: Range<Int>,
     @ViewBuilder content: @escaping (Data.Element) -> Content
   ) {
-    self.data = Array(data)
+    self.data = data
     id = \.self
     self.content = content
   }

--- a/Sources/TokamakDemo/ForEachDemo.swift
+++ b/Sources/TokamakDemo/ForEachDemo.swift
@@ -19,15 +19,15 @@ import TokamakDOM
 #endif
 
 public struct ForEachDemo: View {
-  @State public var items: [Int] = []
+  @State public var maxItem = 0
 
   public var body: some View {
     VStack {
-      Button(action: { items.append((items.last ?? 0) + 1) }) {
+      Button(action: { maxItem += 1 }) {
         Text("Add item")
       }
 
-      ForEach(items, id: \.self) {
+      ForEach(0..<maxItem) {
         Text("Item: \($0)")
       }
     }


### PR DESCRIPTION
This a very minor optimization, it won't need to allocate an array of integers anymore in addition to already holding the array of views in memory. Also tests that the range initializer of `ForEach` is working properly.