### PR TITLE
Use `let` instead of `var` in `TextFieldStyleKey: EnvironmentKey`

### DIFF
--- a/Sources/TokamakCore/Styles/TextFieldStyle.swift
+++ b/Sources/TokamakCore/Styles/TextFieldStyle.swift
@@ -34,7 +34,7 @@ public struct SquareBorderTextFieldStyle: TextFieldStyle {
 }
 
 enum TextFieldStyleKey: EnvironmentKey {
-  static var defaultValue: TextFieldStyle = DefaultTextFieldStyle()
+  static let defaultValue: TextFieldStyle = DefaultTextFieldStyle()
 }
 
 extension EnvironmentValues {


### PR DESCRIPTION
`static var` makes it effectively a global variable, while it should be a constant.