### PR TITLE
Add `Path._Sizing`, `foregroundColor` modifier

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
         "package": "JavaScriptKit",
         "repositoryURL": "https://github.com/kateinoigakukun/JavaScriptKit.git",
         "state": {
-          "branch": "47f2bb1",
-          "revision": "47f2bb16576ba386a2c7c69c97b0fd44f470126f",
+          "branch": "c90e82f",
+          "revision": "c90e82fe1d576a2ccd1aae798380bf80be7885fb",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
   dependencies: [
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
-    .package(url: "https://github.com/kateinoigakukun/JavaScriptKit.git", .revision("47f2bb1")),
+    .package(url: "https://github.com/kateinoigakukun/JavaScriptKit.git", .revision("c90e82f")),
     .package(url: "https://github.com/MaxDesiatov/Runtime.git", .branch("wasi-build")),
     .package(url: "https://github.com/MaxDesiatov/OpenCombine.git", .branch("observable-object")),
   ],

--- a/Sources/TokamakCore/Shapes/Ellipse.swift
+++ b/Sources/TokamakCore/Shapes/Ellipse.swift
@@ -17,7 +17,7 @@
 
 public struct Ellipse: Shape {
   public func path(in rect: CGRect) -> Path {
-    .init(ellipseIn: rect)
+    .init(storage: .ellipse(rect), sizing: .flexible)
   }
 
   public init() {}
@@ -25,7 +25,7 @@ public struct Ellipse: Shape {
 
 public struct Circle: Shape {
   public func path(in rect: CGRect) -> Path {
-    .init(ellipseIn: rect)
+    .init(storage: .ellipse(rect), sizing: .flexible)
   }
 
   public init() {}
@@ -38,9 +38,19 @@ public struct Capsule: Shape {
     self.style = style
   }
 
-  public func path(in r: CGRect) -> Path {
-    .init(roundedRect: r,
-          cornerRadius: min(r.size.width, r.size.height) / 2,
-          style: style)
+  public func path(in rect: CGRect) -> Path {
+    let widthRadius = rect.size.width / 2
+    let heightRadius = rect.size.height / 2
+    return .init(
+      storage: .roundedRect(.init(
+        rect: rect,
+        cornerSize: .init(
+          width: widthRadius,
+          height: heightRadius
+        ),
+        style: style
+      )),
+      sizing: .flexible
+    )
   }
 }

--- a/Sources/TokamakCore/Shapes/Ellipse.swift
+++ b/Sources/TokamakCore/Shapes/Ellipse.swift
@@ -39,9 +39,7 @@ public struct Capsule: Shape {
   }
 
   public func path(in rect: CGRect) -> Path {
-    let widthRadius = rect.size.width / 2
-    let heightRadius = rect.size.height / 2
-    return .init(
+    .init(
       storage: .roundedRect(.init(
         capsule: rect,
         style: style

--- a/Sources/TokamakCore/Shapes/Ellipse.swift
+++ b/Sources/TokamakCore/Shapes/Ellipse.swift
@@ -43,11 +43,7 @@ public struct Capsule: Shape {
     let heightRadius = rect.size.height / 2
     return .init(
       storage: .roundedRect(.init(
-        rect: rect,
-        cornerSize: .init(
-          width: widthRadius,
-          height: heightRadius
-        ),
+        capsule: rect,
         style: style
       )),
       sizing: .flexible

--- a/Sources/TokamakCore/Shapes/FixedRoundedRect.swift
+++ b/Sources/TokamakCore/Shapes/FixedRoundedRect.swift
@@ -1,0 +1,30 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 7/22/20.
+//
+
+public struct FixedRoundedRect: Equatable {
+  public let rect: CGRect
+  public let cornerSize: CGSize?
+  public let style: RoundedCornerStyle
+
+  public init(rect: CGRect, cornerSize: CGSize, style: RoundedCornerStyle) {
+    (self.rect, self.cornerSize, self.style) = (rect, cornerSize, style)
+  }
+
+  init(capsule rect: CGRect, style: RoundedCornerStyle) {
+    (self.rect, cornerSize, self.style) = (rect, nil, style)
+  }
+}

--- a/Sources/TokamakCore/Shapes/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path.swift
@@ -61,6 +61,7 @@ public struct Path: Equatable, LosslessStringConvertible {
   }
 
   public var storage: Storage
+  public let sizing: _Sizing
   public var elements: [Element] = []
   public var transform: CGAffineTransform = .identity
 
@@ -73,37 +74,43 @@ public struct Path: Equatable, LosslessStringConvertible {
 
   public init() {
     storage = .empty
+    sizing = .fixed
   }
 
-  init(storage: Storage) {
+  init(storage: Storage, sizing: _Sizing = .fixed) {
     self.storage = storage
+    self.sizing = sizing
   }
 
   public init(_ rect: CGRect) {
-    storage = .rect(rect)
+    self.init(storage: .rect(rect))
   }
 
   public init(roundedRect rect: CGRect,
               cornerSize: CGSize,
               style: RoundedCornerStyle = .circular) {
-    storage = .roundedRect(FixedRoundedRect(
+    self.init(storage: .roundedRect(FixedRoundedRect(
       rect: rect,
       cornerSize: cornerSize,
       style: style
-    ))
+    )))
   }
 
   public init(roundedRect rect: CGRect,
               cornerRadius: CGFloat,
               style: RoundedCornerStyle = .circular) {
-    storage = .roundedRect(FixedRoundedRect(rect: rect,
-                                            cornerSize: CGSize(width: cornerRadius,
-                                                               height: cornerRadius),
-                                            style: style))
+    self.init(
+      storage: .roundedRect(FixedRoundedRect(
+        rect: rect,
+        cornerSize: CGSize(width: cornerRadius,
+                           height: cornerRadius),
+        style: style
+      ))
+    )
   }
 
   public init(ellipseIn rect: CGRect) {
-    storage = .ellipse(rect)
+    self.init(storage: .ellipse(rect))
   }
 
   public init(_ callback: (inout Self) -> ()) {

--- a/Sources/TokamakCore/Shapes/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path.swift
@@ -164,65 +164,6 @@ public struct Path: Equatable, LosslessStringConvertible {
   //  public init(_ path: CGMutablePath)
 }
 
-public struct FixedRoundedRect: Equatable {
-  public let rect: CGRect
-  public let cornerSize: CGSize?
-  public let style: RoundedCornerStyle
-
-  public init(rect: CGRect, cornerSize: CGSize, style: RoundedCornerStyle) {
-    (self.rect, self.cornerSize, self.style) = (rect, cornerSize, style)
-  }
-
-  init(capsule rect: CGRect, style: RoundedCornerStyle) {
-    (self.rect, cornerSize, self.style) = (rect, nil, style)
-  }
-}
-
-public struct StrokedPath: Equatable {
-  public let path: Path
-  public let style: StrokeStyle
-
-  public init(path: Path, style: StrokeStyle) {
-    self.path = path
-    self.style = style
-  }
-}
-
-public struct TrimmedPath: Equatable {
-  public let path: Path
-  public let from: CGFloat
-  public let to: CGFloat
-
-  public init(path: Path, from: CGFloat, to: CGFloat) {
-    self.path = path
-    self.from = from
-    self.to = to
-  }
-}
-
-public struct StrokeStyle: Equatable {
-  public var lineWidth: CGFloat
-  public var lineCap: CGLineCap
-  public var lineJoin: CGLineJoin
-  public var miterLimit: CGFloat
-  public var dash: [CGFloat]
-  public var dashPhase: CGFloat
-
-  public init(lineWidth: CGFloat = 1,
-              lineCap: CGLineCap = .butt,
-              lineJoin: CGLineJoin = .miter,
-              miterLimit: CGFloat = 10,
-              dash: [CGFloat] = [CGFloat](),
-              dashPhase: CGFloat = 0) {
-    self.lineWidth = lineWidth
-    self.lineCap = lineCap
-    self.lineJoin = lineJoin
-    self.miterLimit = miterLimit
-    self.dash = dash
-    self.dashPhase = dashPhase
-  }
-}
-
 public enum RoundedCornerStyle: Hashable, Equatable {
   case circular
   case continuous

--- a/Sources/TokamakCore/Shapes/Path.swift
+++ b/Sources/TokamakCore/Shapes/Path.swift
@@ -166,8 +166,16 @@ public struct Path: Equatable, LosslessStringConvertible {
 
 public struct FixedRoundedRect: Equatable {
   public let rect: CGRect
-  public let cornerSize: CGSize
+  public let cornerSize: CGSize?
   public let style: RoundedCornerStyle
+
+  public init(rect: CGRect, cornerSize: CGSize, style: RoundedCornerStyle) {
+    (self.rect, self.cornerSize, self.style) = (rect, cornerSize, style)
+  }
+
+  init(capsule rect: CGRect, style: RoundedCornerStyle) {
+    (self.rect, cornerSize, self.style) = (rect, nil, style)
+  }
 }
 
 public struct StrokedPath: Equatable {

--- a/Sources/TokamakCore/Shapes/PathSizing.swift
+++ b/Sources/TokamakCore/Shapes/PathSizing.swift
@@ -1,0 +1,23 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 7/21/20.
+//
+
+extension Path {
+  public enum _Sizing {
+    case fixed
+    case flexible
+  }
+}

--- a/Sources/TokamakCore/Shapes/Rectangle.swift
+++ b/Sources/TokamakCore/Shapes/Rectangle.swift
@@ -14,7 +14,7 @@
 
 public struct Rectangle: Shape {
   public func path(in rect: CGRect) -> Path {
-    .init(rect)
+    .init(storage: .rect(rect), sizing: .flexible)
   }
 
   public init() {}
@@ -35,7 +35,14 @@ public struct RoundedRectangle: Shape {
   }
 
   public func path(in rect: CGRect) -> Path {
-    .init(roundedRect: rect, cornerSize: cornerSize, style: style)
+    .init(
+      storage: .roundedRect(.init(
+        rect: rect,
+        cornerSize: cornerSize,
+        style: style
+      )),
+      sizing: .flexible
+    )
   }
 }
 
@@ -52,9 +59,10 @@ extension Rectangle: InsettableShape {
     }
 
     public func path(in rect: CGRect) -> Path {
-      .init(CGRect(origin: rect.origin,
-                   size: CGSize(width: rect.size.width - (amount / 2),
-                                height: rect.size.height - (amount / 2))))
+      .init(storage: .rect(CGRect(origin: rect.origin,
+                                  size: CGSize(width: rect.size.width - (amount / 2),
+                                               height: rect.size.height - (amount / 2)))),
+            sizing: .flexible)
     }
 
     public func inset(by amount: CGFloat) -> Rectangle._Inset {

--- a/Sources/TokamakCore/Shapes/Shape.swift
+++ b/Sources/TokamakCore/Shapes/Shape.swift
@@ -47,6 +47,7 @@ public struct FillStyle: Equatable, ShapeStyle {
 }
 
 public struct _ShapeView<Content, Style>: View where Content: Shape, Style: ShapeStyle {
+  @Environment(\.foregroundColor) public var foregroundColor
   public var shape: Content
   public var style: Style
   public var fillStyle: FillStyle

--- a/Sources/TokamakCore/Shapes/StrokeStyle.swift
+++ b/Sources/TokamakCore/Shapes/StrokeStyle.swift
@@ -1,0 +1,39 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 7/22/20.
+//
+
+public struct StrokeStyle: Equatable {
+  public var lineWidth: CGFloat
+  public var lineCap: CGLineCap
+  public var lineJoin: CGLineJoin
+  public var miterLimit: CGFloat
+  public var dash: [CGFloat]
+  public var dashPhase: CGFloat
+
+  public init(lineWidth: CGFloat = 1,
+              lineCap: CGLineCap = .butt,
+              lineJoin: CGLineJoin = .miter,
+              miterLimit: CGFloat = 10,
+              dash: [CGFloat] = [CGFloat](),
+              dashPhase: CGFloat = 0) {
+    self.lineWidth = lineWidth
+    self.lineCap = lineCap
+    self.lineJoin = lineJoin
+    self.miterLimit = miterLimit
+    self.dash = dash
+    self.dashPhase = dashPhase
+  }
+}

--- a/Sources/TokamakCore/Shapes/StrokedPath.swift
+++ b/Sources/TokamakCore/Shapes/StrokedPath.swift
@@ -1,0 +1,26 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 7/22/20.
+//
+
+public struct StrokedPath: Equatable {
+  public let path: Path
+  public let style: StrokeStyle
+
+  public init(path: Path, style: StrokeStyle) {
+    self.path = path
+    self.style = style
+  }
+}

--- a/Sources/TokamakCore/Shapes/TrimmedPath.swift
+++ b/Sources/TokamakCore/Shapes/TrimmedPath.swift
@@ -1,0 +1,28 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Carson Katri on 7/22/20.
+//
+
+public struct TrimmedPath: Equatable {
+  public let path: Path
+  public let from: CGFloat
+  public let to: CGFloat
+
+  public init(path: Path, from: CGFloat, to: CGFloat) {
+    self.path = path
+    self.from = from
+    self.to = to
+  }
+}

--- a/Sources/TokamakCore/Tokens/Color.swift
+++ b/Sources/TokamakCore/Tokens/Color.swift
@@ -158,3 +158,24 @@ extension Color {
     envAccentColor ?? .blue
   }
 }
+
+struct ForegroundColorKey: EnvironmentKey {
+  static let defaultValue: Color? = nil
+}
+
+public extension EnvironmentValues {
+  var foregroundColor: Color? {
+    get {
+      self[ForegroundColorKey.self]
+    }
+    set {
+      self[ForegroundColorKey.self] = newValue
+    }
+  }
+}
+
+extension View {
+  public func foregroundColor(_ color: Color?) -> some View {
+    environment(\.foregroundColor, color)
+  }
+}

--- a/Sources/TokamakDOM/Shapes/Path.swift
+++ b/Sources/TokamakDOM/Shapes/Path.swift
@@ -30,26 +30,30 @@ extension Path: ViewDeferredToRenderer {
       "stroke-width": "\(strokeStyle.lineWidth)",
     ]
     let uniqueKeys = { (first: String, _: String) in first }
+    let width: String? = sizing == .flexible ? "100%" : nil
+    let height: String? = sizing == .flexible ? "100%" : nil
+    let centerX: String? = sizing == .flexible ? "50%" : nil
+    let centerY: String? = sizing == .flexible ? "50%" : nil
     switch storage {
     case .empty:
       return AnyView(EmptyView())
     case let .rect(rect):
       return AnyView(AnyView(HTML("rect", [
-        "width": "\(max(0, rect.size.width))",
-        "height": "\(max(0, rect.size.height))",
+        "width": width ?? "\(max(0, rect.size.width))",
+        "height": height ?? "\(max(0, rect.size.height))",
         "x": "\(rect.origin.x - (rect.size.width / 2))",
         "y": "\(rect.origin.y - (rect.size.height / 2))",
       ].merging(stroke, uniquingKeysWith: uniqueKeys))))
     case let .ellipse(rect):
-      return AnyView(HTML("ellipse", ["cx": "\(rect.origin.x)",
-                                      "cy": "\(rect.origin.y)",
-                                      "rx": "\(rect.size.width)",
-                                      "ry": "\(rect.size.height)"]
+      return AnyView(HTML("ellipse", ["cx": centerX ?? "\(rect.origin.x)",
+                                      "cy": centerY ?? "\(rect.origin.y)",
+                                      "rx": centerX ?? "\(rect.size.width)",
+                                      "ry": centerY ?? "\(rect.size.height)"]
           .merging(stroke, uniquingKeysWith: uniqueKeys)))
     case let .roundedRect(roundedRect):
       return AnyView(HTML("rect", [
-        "width": "\(roundedRect.rect.size.width)",
-        "height": "\(roundedRect.rect.size.height)",
+        "width": width ?? "\(roundedRect.rect.size.width)",
+        "height": height ?? "\(roundedRect.rect.size.height)",
         "rx": "\(roundedRect.cornerSize.width)",
         "ry": """
         \(roundedRect.style == .continuous ?
@@ -161,9 +165,17 @@ extension Path: ViewDeferredToRenderer {
   }
 
   public var deferredBody: AnyView {
-    AnyView(HTML("svg", ["style": """
-    width: \(max(0, size.width));
-    height: \(max(0, size.height));
+    let sizeStyle = sizing == .flexible ?
+      """
+      width: 100%;
+      height: 100%;
+      """ :
+      """
+      width: \(max(0, size.width));
+      height: \(max(0, size.height));
+      """
+    return AnyView(HTML("svg", ["style": """
+    \(sizeStyle)
     overflow: visible;
     """]) {
       svgBody()

--- a/Sources/TokamakDOM/Shapes/_ShapeView.swift
+++ b/Sources/TokamakDOM/Shapes/_ShapeView.swift
@@ -38,6 +38,8 @@ extension _ShapeView: ViewDeferredToRenderer {
       return AnyView(HTML("div", shapeAttributes.attributes(style)) { path })
     } else if let color = style as? Color {
       return AnyView(HTML("div", ["style": "fill: \(color);"]) { path })
+    } else if let foregroundColor = foregroundColor {
+      return AnyView(HTML("div", ["style": "fill: \(foregroundColor);"]) { path })
     } else {
       return path
     }

--- a/Sources/TokamakDemo/PathDemo.swift
+++ b/Sources/TokamakDemo/PathDemo.swift
@@ -52,6 +52,8 @@ struct PathDemo: View {
           .frame(width: 25, height: 25)
         Rectangle()
           .frame(width: 25, height: 25)
+        Capsule()
+          .frame(width: 50, height: 25)
       }
       .foregroundColor(Color.blue)
     }

--- a/Sources/TokamakDemo/PathDemo.swift
+++ b/Sources/TokamakDemo/PathDemo.swift
@@ -47,6 +47,13 @@ struct PathDemo: View {
       }
       .stroke(Color(red: 1, green: 0.75, blue: 0.1, opacity: 1), lineWidth: 4)
       .padding(.vertical)
+      HStack {
+        Circle()
+          .frame(width: 25, height: 25)
+        Rectangle()
+          .frame(width: 25, height: 25)
+      }
+      .foregroundColor(Color.blue)
     }
   }
 }


### PR DESCRIPTION
This resolves #185 by adding a `_Sizing` enum to `Path` which tells the renderer if the path should be a `fixed` size, or `flexible`.