### PR TITLE
Bump JavaScriptKit to 0.5.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
         "package": "JavaScriptKit",
         "repositoryURL": "https://github.com/kateinoigakukun/JavaScriptKit.git",
         "state": {
-          "branch": "47f2bb1",
-          "revision": "47f2bb16576ba386a2c7c69c97b0fd44f470126f",
+          "branch": "c90e82f",
+          "revision": "c90e82fe1d576a2ccd1aae798380bf80be7885fb",
           "version": null
         }
       },

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
   dependencies: [
     // Dependencies declare other packages that this package depends on.
     // .package(url: /* package url */, from: "1.0.0"),
-    .package(url: "https://github.com/kateinoigakukun/JavaScriptKit.git", .revision("47f2bb1")),
+    .package(url: "https://github.com/kateinoigakukun/JavaScriptKit.git", .revision("c90e82f")),
     .package(url: "https://github.com/MaxDesiatov/Runtime.git", .branch("wasi-build")),
     .package(url: "https://github.com/MaxDesiatov/OpenCombine.git", .branch("observable-object")),
   ],


### PR DESCRIPTION
This change is required to make Tokamak compatible with `carton` 0.4, which bundles the latest JavaScriptKit runtime. Currently the new runtime and old Swift parts of JavaScriptKit are incompatible with each other, which leads to a white screen when building and running Tokamak from `main` with `carton` 0.4.

It's already a part of a couple of other PRs, but opening this one separately to expedite it as `carton` 0.4 is already released. I haven't announced it widely yet, so I hope we can merge this in quickly to avoid any confusion among our early adopters who try to use Tokamak with the latest version of `carton` 🙂