### PR TITLE
Add basic `ButtonStyle` implementation

### DIFF
--- a/NativeDemo/TokamakDemo.xcodeproj/project.pbxproj
+++ b/NativeDemo/TokamakDemo.xcodeproj/project.pbxproj
@@ -39,6 +39,8 @@
 		D1B4229124B3B9BB00682F74 /* ListDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4228E24B3B9BB00682F74 /* ListDemo.swift */; };
 		D1B4229224B3B9BB00682F74 /* OutlineGroupDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4228F24B3B9BB00682F74 /* OutlineGroupDemo.swift */; };
 		D1B4229324B3B9BB00682F74 /* OutlineGroupDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4228F24B3B9BB00682F74 /* OutlineGroupDemo.swift */; };
+		D1C726F324CB63C6003B576D /* ButtonStyleDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C726F224CB63C6003B576D /* ButtonStyleDemo.swift */; };
+		D1C726F424CB63C6003B576D /* ButtonStyleDemo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1C726F224CB63C6003B576D /* ButtonStyleDemo.swift */; };
 		D1E5FDAD24C1D57000E7485E /* TokamakShim.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1E5FDAC24C1D57000E7485E /* TokamakShim.swift */; };
 		D1E5FDAF24C1D58E00E7485E /* libTokamakShim.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D1E5FDA424C1D54B00E7485E /* libTokamakShim.a */; };
 		D1E5FDB224C1D59400E7485E /* libTokamakShim.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D1E5FDA424C1D54B00E7485E /* libTokamakShim.a */; };
@@ -98,6 +100,7 @@
 		B5C76E4924C73ED4003EABB2 /* AppStorageDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppStorageDemo.swift; sourceTree = "<group>"; };
 		D1B4228E24B3B9BB00682F74 /* ListDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ListDemo.swift; sourceTree = "<group>"; };
 		D1B4228F24B3B9BB00682F74 /* OutlineGroupDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OutlineGroupDemo.swift; sourceTree = "<group>"; };
+		D1C726F224CB63C6003B576D /* ButtonStyleDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ButtonStyleDemo.swift; sourceTree = "<group>"; };
 		D1E5FDA424C1D54B00E7485E /* libTokamakShim.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libTokamakShim.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		D1E5FDAC24C1D57000E7485E /* TokamakShim.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TokamakShim.swift; sourceTree = "<group>"; };
 		D1EE7EA624C0DD2100C0D127 /* PickerDemo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PickerDemo.swift; sourceTree = "<group>"; };
@@ -159,6 +162,7 @@
 		85ED189924AD425E0085DFA0 /* TokamakDemo */ = {
 			isa = PBXGroup;
 			children = (
+				D1C726F224CB63C6003B576D /* ButtonStyleDemo.swift */,
 				B5C76E4924C73ED4003EABB2 /* AppStorageDemo.swift */,
 				D1EE7EA624C0DD2100C0D127 /* PickerDemo.swift */,
 				D1B4228E24B3B9BB00682F74 /* ListDemo.swift */,
@@ -330,6 +334,7 @@
 				B5C76E4A24C73ED5003EABB2 /* AppStorageDemo.swift in Sources */,
 				85ED18AD24AD425E0085DFA0 /* TextFieldDemo.swift in Sources */,
 				85ED18A724AD425E0085DFA0 /* ForEachDemo.swift in Sources */,
+				D1C726F324CB63C6003B576D /* ButtonStyleDemo.swift in Sources */,
 				854A1A9124B3E3630027BC32 /* ToggleDemo.swift in Sources */,
 				85ED18A524AD425E0085DFA0 /* TextDemo.swift in Sources */,
 				85ED18AB24AD425E0085DFA0 /* Counter.swift in Sources */,
@@ -353,6 +358,7 @@
 				B5C76E4B24C73ED5003EABB2 /* AppStorageDemo.swift in Sources */,
 				85ED18AC24AD425E0085DFA0 /* Counter.swift in Sources */,
 				85ED18A824AD425E0085DFA0 /* ForEachDemo.swift in Sources */,
+				D1C726F424CB63C6003B576D /* ButtonStyleDemo.swift in Sources */,
 				854A1A9324B3F28F0027BC32 /* ToggleDemo.swift in Sources */,
 				85ED18AE24AD425E0085DFA0 /* TextFieldDemo.swift in Sources */,
 				85ED18A624AD425E0085DFA0 /* TextDemo.swift in Sources */,

--- a/Sources/TokamakCore/DynamicProperty.swift
+++ b/Sources/TokamakCore/DynamicProperty.swift
@@ -24,34 +24,3 @@ public protocol DynamicProperty {
 extension DynamicProperty {
   public mutating func update() {}
 }
-
-extension TypeInfo {
-  /// Extract all `DynamicProperty` from a type, recursively.
-  /// This is necessary as a `DynamicProperty` can be nested.
-  /// `EnvironmentValues` can also be injected at this point.
-  func dynamicProperties(_ environment: EnvironmentValues,
-                         source: inout Any,
-                         shouldUpdate: Bool) -> [PropertyInfo] {
-    var dynamicProps = [PropertyInfo]()
-    for prop in properties where prop.type is DynamicProperty.Type {
-      dynamicProps.append(prop)
-      // swiftlint:disable force_try
-      let propInfo = try! typeInfo(of: prop.type)
-      _ = propInfo.injectEnvironment(from: environment, into: &source)
-      var extracted = try! prop.get(from: source)
-      dynamicProps.append(
-        contentsOf: propInfo.dynamicProperties(environment,
-                                               source: &extracted,
-                                               shouldUpdate: shouldUpdate)
-      )
-      // swiftlint:disable:next force_cast
-      var extractedDynamicProp = extracted as! DynamicProperty
-      if shouldUpdate {
-        extractedDynamicProp.update()
-      }
-      try! prop.set(value: extractedDynamicProp, on: &source)
-      // swiftlint:enable force_try
-    }
-    return dynamicProps
-  }
-}

--- a/Sources/TokamakCore/DynamicProperty.swift
+++ b/Sources/TokamakCore/DynamicProperty.swift
@@ -37,7 +37,7 @@ extension TypeInfo {
       dynamicProps.append(prop)
       // swiftlint:disable force_try
       let propInfo = try! typeInfo(of: prop.type)
-      propInfo.injectEnvironment(from: environment, into: &source)
+      _ = propInfo.injectEnvironment(from: environment, into: &source)
       var extracted = try! prop.get(from: source)
       dynamicProps.append(
         contentsOf: propInfo.dynamicProperties(environment,

--- a/Sources/TokamakCore/Environment/EnvironmentValues.swift
+++ b/Sources/TokamakCore/Environment/EnvironmentValues.swift
@@ -45,6 +45,21 @@ public struct EnvironmentValues: CustomStringConvertible {
   }
 }
 
+struct IsEnabledKey: EnvironmentKey {
+  static let defaultValue = true
+}
+
+extension EnvironmentValues {
+  public var isEnabled: Bool {
+    get {
+      self[IsEnabledKey.self]
+    }
+    set {
+      self[IsEnabledKey.self] = newValue
+    }
+  }
+}
+
 struct _EnvironmentValuesWritingModifier: ViewModifier, EnvironmentModifier {
   let environmentValues: EnvironmentValues
 

--- a/Sources/TokamakCore/MountedViews/MountedApp.swift
+++ b/Sources/TokamakCore/MountedViews/MountedApp.swift
@@ -57,20 +57,3 @@ final class MountedApp<R: Renderer>: MountedCompositeElement<R> {
     )
   }
 }
-
-extension _AnyApp {
-  func makeMountedApp<R>(
-    _ parentTarget: R.TargetType,
-    _ environmentValues: EnvironmentValues
-  ) -> MountedApp<R> where R: Renderer {
-    // swiftlint:disable:next force_try
-    let info = try! typeInfo(of: type)
-
-    var modifiedApp = app
-    let modifiedEnv = info.injectEnvironment(from: environmentValues, into: &modifiedApp)
-
-    var result = self
-    result.app = modifiedApp
-    return MountedApp(result, parentTarget, modifiedEnv)
-  }
-}

--- a/Sources/TokamakCore/MountedViews/MountedApp.swift
+++ b/Sources/TokamakCore/MountedViews/MountedApp.swift
@@ -66,11 +66,11 @@ extension _AnyApp {
     // swiftlint:disable:next force_try
     let info = try! typeInfo(of: type)
 
-    var modified = app
-    info.injectEnvironment(from: environmentValues, into: &modified)
+    var modifiedApp = app
+    let modifiedEnv = info.injectEnvironment(from: environmentValues, into: &modifiedApp)
 
     var result = self
-    result.app = modified
-    return MountedApp(result, parentTarget, environmentValues)
+    result.app = modifiedApp
+    return MountedApp(result, parentTarget, modifiedEnv)
   }
 }

--- a/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
@@ -17,24 +17,15 @@
 
 import OpenCombine
 
-class MountedCompositeElement<R: Renderer>: MountedElement<R>, Hashable {
-  static func == (lhs: MountedCompositeElement<R>,
-                  rhs: MountedCompositeElement<R>) -> Bool {
-    lhs === rhs
-  }
-
-  func hash(into hasher: inout Hasher) {
-    hasher.combine(ObjectIdentifier(self))
-  }
-
+class MountedCompositeElement<R: Renderer>: MountedElement<R> {
   let parentTarget: R.TargetType
 
   var state = [Any]()
   var subscriptions = [AnyCancellable]()
 
-  init(_ app: _AnyApp, _ parentTarget: R.TargetType, _ environmentValues: EnvironmentValues) {
+  init<A: App>(_ app: A, _ parentTarget: R.TargetType, _ environmentValues: EnvironmentValues) {
     self.parentTarget = parentTarget
-    super.init(app, environmentValues)
+    super.init(_AnyApp(app), environmentValues)
   }
 
   init(_ scene: _AnyScene, _ parentTarget: R.TargetType, _ environmentValues: EnvironmentValues) {
@@ -45,5 +36,16 @@ class MountedCompositeElement<R: Renderer>: MountedElement<R>, Hashable {
   init(_ view: AnyView, _ parentTarget: R.TargetType, _ environmentValues: EnvironmentValues) {
     self.parentTarget = parentTarget
     super.init(view, environmentValues)
+  }
+}
+
+extension MountedCompositeElement: Hashable {
+  static func == (lhs: MountedCompositeElement<R>,
+                  rhs: MountedCompositeElement<R>) -> Bool {
+    lhs === rhs
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(self))
   }
 }

--- a/Sources/TokamakCore/MountedViews/MountedElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedElement.swift
@@ -117,16 +117,16 @@ public class MountedElement<R: Renderer> {
 }
 
 extension TypeInfo {
-  func injectEnvironment(from environmentValues: EnvironmentValues, into element: inout Any) -> EnvironmentValues {
+  func injectEnvironment(
+    from environmentValues: EnvironmentValues,
+    into element: inout Any
+  ) -> EnvironmentValues {
     var modifiedEnv = environmentValues
     // swiftlint:disable force_try
-    // Extract the view from the AnyView for modification
-    if genericTypes.filter({ $0 is EnvironmentModifier.Type }).count > 0 {
-      // Apply Environment changes:
-      if let modifier = try! property(named: "modifier").get(from: element) as? EnvironmentModifier {
-        print("modifier found: \(modifier)")
-        modifier.modifyEnvironment(&modifiedEnv)
-      }
+    // Extract the view from the AnyView for modification, apply Environment changes:
+    if genericTypes.contains(where: { $0 is EnvironmentModifier.Type }),
+      let modifier = try! property(named: "modifier").get(from: element) as? EnvironmentModifier {
+      modifier.modifyEnvironment(&modifiedEnv)
     }
 
     // Inject @Environment values

--- a/Sources/TokamakCore/MountedViews/MountedHostView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedHostView.swift
@@ -66,9 +66,7 @@ public final class MountedHostView<R: Renderer>: MountedElement<R> {
   override func update(with reconciler: StackReconciler<R>) {
     guard let target = target else { return }
 
-    // swiftlint:disable:next force_try
-    let viewInfo = try! typeInfo(of: view.type)
-    environmentValues = viewInfo.injectEnvironment(from: environmentValues, into: &view.view)
+    updateEnvironment()
     target.view = view
     reconciler.renderer?.update(target: target, with: self)
 
@@ -97,11 +95,7 @@ public final class MountedHostView<R: Renderer>: MountedElement<R> {
         let newChild: MountedElement<R>
         if firstChild.typeConstructorName == mountedChildren[0].view.typeConstructorName {
           child.view = firstChild
-          // Inject Environment
-          // swiftlint:disable:next force_try
-          let viewInfo = try! typeInfo(of: child.view.type)
-          child.environmentValues =
-            viewInfo.injectEnvironment(from: environmentValues, into: &child.view.view)
+          child.updateEnvironment()
           child.update(with: reconciler)
           newChild = child
         } else {

--- a/Sources/TokamakCore/MountedViews/MountedHostView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedHostView.swift
@@ -38,9 +38,7 @@ public final class MountedHostView<R: Renderer>: MountedElement<R> {
   }
 
   override func mount(with reconciler: StackReconciler<R>) {
-    guard
-      let target = reconciler.renderer?.mountTarget(to: parentTarget,
-                                                    with: self)
+    guard let target = reconciler.renderer?.mountTarget(to: parentTarget, with: self)
     else { return }
 
     self.target = target
@@ -68,6 +66,9 @@ public final class MountedHostView<R: Renderer>: MountedElement<R> {
   override func update(with reconciler: StackReconciler<R>) {
     guard let target = target else { return }
 
+    // swiftlint:disable:next force_try
+    let viewInfo = try! typeInfo(of: view.type)
+    viewInfo.injectEnvironment(from: environmentValues, into: &view.view)
     target.view = view
     reconciler.renderer?.update(target: target, with: self)
 

--- a/Sources/TokamakCore/MountedViews/MountedHostView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedHostView.swift
@@ -68,7 +68,7 @@ public final class MountedHostView<R: Renderer>: MountedElement<R> {
 
     // swiftlint:disable:next force_try
     let viewInfo = try! typeInfo(of: view.type)
-    viewInfo.injectEnvironment(from: environmentValues, into: &view.view)
+    environmentValues = viewInfo.injectEnvironment(from: environmentValues, into: &view.view)
     target.view = view
     reconciler.renderer?.update(target: target, with: self)
 
@@ -100,7 +100,8 @@ public final class MountedHostView<R: Renderer>: MountedElement<R> {
           // Inject Environment
           // swiftlint:disable:next force_try
           let viewInfo = try! typeInfo(of: child.view.type)
-          viewInfo.injectEnvironment(from: environmentValues, into: &child.view.view)
+          child.environmentValues =
+            viewInfo.injectEnvironment(from: environmentValues, into: &child.view.view)
           child.update(with: reconciler)
           newChild = child
         } else {

--- a/Sources/TokamakCore/MountedViews/MountedScene.swift
+++ b/Sources/TokamakCore/MountedViews/MountedScene.swift
@@ -92,25 +92,25 @@ extension _AnyScene {
     // swiftlint:disable:next force_try
     let info = try! typeInfo(of: type)
 
-    var modified = scene
-    info.injectEnvironment(from: environmentValues, into: &modified)
+    var modifiedScene = scene
+    let modifiedEnv = info.injectEnvironment(from: environmentValues, into: &modifiedScene)
 
     var title: String?
-    if let titledSelf = modified as? TitledScene,
+    if let titledSelf = modifiedScene as? TitledScene,
       let text = titledSelf.title {
       title = _TextProxy(text).rawText
     }
     let children: [MountedElement<R>]
-    if let deferredScene = modified as? SceneDeferredToRenderer {
-      children = [deferredScene.deferredBody.makeMountedView(parentTarget, environmentValues)]
-    } else if let groupScene = modified as? GroupScene {
-      children = groupScene.children.map { $0.makeMountedScene(parentTarget, environmentValues) }
+    if let deferredScene = modifiedScene as? SceneDeferredToRenderer {
+      children = [deferredScene.deferredBody.makeMountedView(parentTarget, modifiedEnv)]
+    } else if let groupScene = modifiedScene as? GroupScene {
+      children = groupScene.children.map { $0.makeMountedScene(parentTarget, modifiedEnv) }
     } else {
       children = []
     }
 
     var result = self
-    result.scene = modified
-    return .init(result, title, children, parentTarget, environmentValues)
+    result.scene = modifiedScene
+    return .init(result, title, children, parentTarget, modifiedEnv)
   }
 }

--- a/Sources/TokamakCore/MountedViews/MountedScene.swift
+++ b/Sources/TokamakCore/MountedViews/MountedScene.swift
@@ -89,28 +89,19 @@ extension _AnyScene {
     _ parentTarget: R.TargetType,
     _ environmentValues: EnvironmentValues
   ) -> MountedScene<R> {
-    // swiftlint:disable:next force_try
-    let info = try! typeInfo(of: type)
-
-    var modifiedScene = scene
-    let modifiedEnv = info.injectEnvironment(from: environmentValues, into: &modifiedScene)
-
     var title: String?
-    if let titledSelf = modifiedScene as? TitledScene,
+    if let titledSelf = scene as? TitledScene,
       let text = titledSelf.title {
       title = _TextProxy(text).rawText
     }
     let children: [MountedElement<R>]
-    if let deferredScene = modifiedScene as? SceneDeferredToRenderer {
-      children = [deferredScene.deferredBody.makeMountedView(parentTarget, modifiedEnv)]
-    } else if let groupScene = modifiedScene as? GroupScene {
-      children = groupScene.children.map { $0.makeMountedScene(parentTarget, modifiedEnv) }
+    if let deferredScene = scene as? SceneDeferredToRenderer {
+      children = [deferredScene.deferredBody.makeMountedView(parentTarget, environmentValues)]
+    } else if let groupScene = scene as? GroupScene {
+      children = groupScene.children.map { $0.makeMountedScene(parentTarget, environmentValues) }
     } else {
       children = []
     }
-
-    var result = self
-    result.scene = modifiedScene
-    return .init(result, title, children, parentTarget, modifiedEnv)
+    return .init(self, title, children, parentTarget, environmentValues)
   }
 }

--- a/Sources/TokamakCore/StackReconciler.swift
+++ b/Sources/TokamakCore/StackReconciler.swift
@@ -179,8 +179,10 @@ public final class StackReconciler<R: Renderer> {
                  body bodyKeypath: ReferenceWritableKeyPath<MountedCompositeElement<R>, Any>,
                  result: KeyPath<MountedCompositeElement<R>, (Any) -> T>) -> T {
     let info = try! typeInfo(of: compositeElement.elementType)
-    info.injectEnvironment(from: compositeElement.environmentValues,
-                           into: &compositeElement[keyPath: bodyKeypath])
+    compositeElement.environmentValues = info.injectEnvironment(
+      from: compositeElement.environmentValues,
+      into: &compositeElement[keyPath: bodyKeypath]
+    )
 
     let needsSubscriptions = compositeElement.subscriptions.isEmpty
 

--- a/Sources/TokamakCore/StackReconciler.swift
+++ b/Sources/TokamakCore/StackReconciler.swift
@@ -90,7 +90,7 @@ public final class StackReconciler<R: Renderer> {
     self.scheduler = scheduler
     rootTarget = target
 
-    rootElement = _AnyApp(app).makeMountedApp(target, environment)
+    rootElement = MountedApp(app, target, environment)
 
     rootElement.mount(with: self)
     if let mountedApp = rootElement as? MountedApp<R> {
@@ -147,9 +147,8 @@ public final class StackReconciler<R: Renderer> {
     if state.getter == nil || state.setter == nil {
       state.getter = { compositeElement.state[id] }
 
-      // Avoiding an indirect reference cycle here: this closure can be
-      // owned by callbacks owned by view's target, which is strongly referenced
-      // by the reconciler.
+      // Avoiding an indirect reference cycle here: this closure can be owned by callbacks
+      // owned by view's target, which is strongly referenced by the reconciler.
       state.setter = { [weak self, weak compositeElement] newValue in
         guard let element = compositeElement else { return }
         self?.queueStateUpdate(for: element, id: id) { $0 = newValue }
@@ -178,18 +177,15 @@ public final class StackReconciler<R: Renderer> {
   func render<T>(compositeElement: MountedCompositeElement<R>,
                  body bodyKeypath: ReferenceWritableKeyPath<MountedCompositeElement<R>, Any>,
                  result: KeyPath<MountedCompositeElement<R>, (Any) -> T>) -> T {
-    let info = try! typeInfo(of: compositeElement.elementType)
-    compositeElement.environmentValues = info.injectEnvironment(
-      from: compositeElement.environmentValues,
-      into: &compositeElement[keyPath: bodyKeypath]
+    let info = compositeElement.updateEnvironment()
+
+    var stateIdx = 0
+    let dynamicProps = info.dynamicProperties(
+      compositeElement.environmentValues,
+      source: &compositeElement[keyPath: bodyKeypath]
     )
 
     let needsSubscriptions = compositeElement.subscriptions.isEmpty
-
-    var stateIdx = 0
-    let dynamicProps = info.dynamicProperties(compositeElement.environmentValues,
-                                              source: &compositeElement[keyPath: bodyKeypath],
-                                              shouldUpdate: true)
     for property in dynamicProps {
       // Setup state/subscriptions
       if property.type is ValueStorage.Type {

--- a/Sources/TokamakCore/Styles/ButtonStyle.swift
+++ b/Sources/TokamakCore/Styles/ButtonStyle.swift
@@ -15,7 +15,7 @@
 //  Created by Gene Z. Ragan on 07/22/2020.
 
 public struct ButtonStyleConfiguration {
-  public let label: String
+  public let label: AnyView!
   public let action: () -> ()
   public var isPressed = false
 }

--- a/Sources/TokamakCore/Styles/ButtonStyle.swift
+++ b/Sources/TokamakCore/Styles/ButtonStyle.swift
@@ -59,8 +59,10 @@ public struct _AnyButtonStyle: ButtonStyle {
   public typealias Body = AnyView
 
   private let bodyClosure: (ButtonStyleConfiguration) -> AnyView
+  public let type: Any.Type
 
   public init<S: ButtonStyle>(_ style: S) {
+    type = S.self
     bodyClosure = { configuration in
       AnyView(style.makeBody(configuration: configuration))
     }

--- a/Sources/TokamakCore/Styles/ButtonStyle.swift
+++ b/Sources/TokamakCore/Styles/ButtonStyle.swift
@@ -1,0 +1,68 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Gene Z. Ragan on 07/22/2020.
+
+public struct ButtonStyleConfiguration {
+  public let label: String
+  public let action: () -> ()
+  public var isPressed = false
+}
+
+public protocol ButtonStyle {
+  associatedtype Body: View
+
+  func makeBody(configuration: Self.Configuration) -> Self.Body
+
+  typealias Configuration = ButtonStyleConfiguration
+}
+
+public struct AnyButtonStyle: ButtonStyle {
+  public typealias Body = AnyView
+
+  private let bodyClosure: (ButtonStyleConfiguration) -> AnyView
+
+  public init<S: ButtonStyle>(_ style: S) {
+    bodyClosure = { configuration in
+      AnyView(style.makeBody(configuration: configuration))
+    }
+  }
+
+  public func makeBody(configuration: ButtonStyleConfiguration) -> AnyView {
+    bodyClosure(configuration)
+  }
+}
+
+public enum ButtonStyleKey: EnvironmentKey {
+  public static var defaultValue: AnyButtonStyle {
+    fatalError("\(self) must have a renderer-provided default value")
+  }
+}
+
+extension EnvironmentValues {
+  var buttonStyle: AnyButtonStyle {
+    get {
+      self[ButtonStyleKey.self]
+    }
+    set {
+      self[ButtonStyleKey.self] = newValue
+    }
+  }
+}
+
+extension View {
+  public func buttonStyle<S>(_ style: S) -> some View where S: ButtonStyle {
+    environment(\.buttonStyle, AnyButtonStyle(style))
+  }
+}

--- a/Sources/TokamakCore/Styles/ToggleStyle.swift
+++ b/Sources/TokamakCore/Styles/ToggleStyle.swift
@@ -52,7 +52,7 @@ public struct _AnyToggleStyle: ToggleStyle {
   }
 }
 
-public enum ToggleStyleKey: EnvironmentKey {
+public enum _ToggleStyleKey: EnvironmentKey {
   public static var defaultValue: _AnyToggleStyle {
     fatalError("\(self) must have a renderer-provided default value")
   }
@@ -61,10 +61,10 @@ public enum ToggleStyleKey: EnvironmentKey {
 extension EnvironmentValues {
   var toggleStyle: _AnyToggleStyle {
     get {
-      self[ToggleStyleKey.self]
+      self[_ToggleStyleKey.self]
     }
     set {
-      self[ToggleStyleKey.self] = newValue
+      self[_ToggleStyleKey.self] = newValue
     }
   }
 }

--- a/Sources/TokamakCore/Views/Buttons/Button.swift
+++ b/Sources/TokamakCore/Views/Buttons/Button.swift
@@ -51,7 +51,7 @@ public struct _Button<Label>: View where Label: View {
   public let label: Label
   public let action: () -> ()
   @State public var isPressed = false
-  @Environment(\.buttonStyle) public var buttonStyle: _AnyButtonStyle
+  @Environment(\.buttonStyle) public var buttonStyle
 
   public init(action: @escaping () -> (), label: Label) {
     self.label = label

--- a/Sources/TokamakCore/Views/Buttons/Button.swift
+++ b/Sources/TokamakCore/Views/Buttons/Button.swift
@@ -36,21 +36,30 @@
 ///       Button("\(counter)", action: { counter += 1 })
 ///     }
 public struct Button<Label>: View where Label: View {
-  let label: Label
-  @Environment(\.buttonStyle) var buttonStyle: AnyButtonStyle
-
-  let action: () -> ()
+  let button: _Button<Label>
 
   public init(action: @escaping () -> (), @ViewBuilder label: () -> Label) {
-    self.label = label()
+    button = _Button(action: action, label: label())
+  }
+
+  public var body: some View {
+    button
+  }
+}
+
+public struct _Button<Label>: View where Label: View {
+  public let label: Label
+  public let action: () -> ()
+  @State public var isPressed = false
+  @Environment(\.buttonStyle) public var buttonStyle: _AnyButtonStyle
+
+  public init(action: @escaping () -> (), label: Label) {
+    self.label = label
     self.action = action
   }
 
-  public var body: AnyView {
-    buttonStyle.makeBody(
-      configuration: ButtonStyleConfiguration(label: AnyView(label),
-                                              action: action)
-    )
+  public var body: Never {
+    neverBody("_Button")
   }
 }
 
@@ -64,6 +73,6 @@ extension Button where Label == Text {
 
 extension Button: ParentView {
   public var children: [AnyView] {
-    (label as? GroupView)?.children ?? [AnyView(label)]
+    (button.label as? GroupView)?.children ?? [AnyView(button.label)]
   }
 }

--- a/Sources/TokamakCore/Views/Buttons/Button.swift
+++ b/Sources/TokamakCore/Views/Buttons/Button.swift
@@ -37,6 +37,7 @@
 ///     }
 public struct Button<Label>: View where Label: View {
   let label: Label
+  @Environment(\.buttonStyle) var buttonStyle: AnyButtonStyle
 
   let action: () -> ()
 
@@ -45,8 +46,11 @@ public struct Button<Label>: View where Label: View {
     self.action = action
   }
 
-  public var body: Never {
-    neverBody("Button")
+  public var body: AnyView {
+    buttonStyle.makeBody(
+      configuration: ButtonStyleConfiguration(label: AnyView(label),
+                                              action: action)
+    )
   }
 }
 
@@ -62,16 +66,4 @@ extension Button: ParentView {
   public var children: [AnyView] {
     (label as? GroupView)?.children ?? [AnyView(label)]
   }
-}
-
-/// This is a helper class that works around absence of "package private" access control in Swift
-public struct _ButtonProxy<Label> where Label: View {
-  let subject: Button<Label>
-
-  public init(_ subject: Button<Label>) { self.subject = subject }
-  public var action: () -> () { subject.action }
-}
-
-extension _ButtonProxy where Label == Text {
-  public var label: _TextProxy { _TextProxy(subject.label) }
 }

--- a/Sources/TokamakCore/Views/Text/Text.swift
+++ b/Sources/TokamakCore/Views/Text/Text.swift
@@ -33,7 +33,8 @@ public struct Text: View {
   let storage: _Storage
   let modifiers: [_Modifier]
 
-  @Environment(\.font) var font: Font?
+  @Environment(\.font) var font
+  @Environment(\.foregroundColor) var foregroundColor
 
   public enum _Storage {
     case verbatim(String)
@@ -99,15 +100,12 @@ public struct _TextProxy {
   public var modifiers: [Text._Modifier] {
     [
       .font(subject.font),
+      .color(subject.foregroundColor),
     ] + subject.modifiers
   }
 }
 
 public extension Text {
-  func foregroundColor(_ color: Color?) -> Text {
-    .init(storage: storage, modifiers: modifiers + [.color(color)])
-  }
-
   func font(_ font: Font?) -> Text {
     .init(storage: storage, modifiers: modifiers + [.font(font)])
   }

--- a/Sources/TokamakDOM/Core.swift
+++ b/Sources/TokamakDOM/Core.swift
@@ -51,6 +51,9 @@ public typealias RadioGroupPickerStyle = TokamakCore.RadioGroupPickerStyle
 public typealias SegmentedPickerStyle = TokamakCore.SegmentedPickerStyle
 public typealias WheelPickerStyle = TokamakCore.WheelPickerStyle
 
+public typealias ButtonStyle = TokamakCore.ButtonStyle
+public typealias ButtonStyleConfiguration = TokamakCore.ButtonStyleConfiguration
+
 // MARK: Shapes
 
 public typealias Shape = TokamakCore.Shape

--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -85,7 +85,7 @@ public final class DOMRenderer: Renderer {
 
   public init<V: View>(_ view: V,
                        _ ref: JSObjectRef,
-                       _ rootEnvironment: EnvironmentValues? = nil) {
+                       _: EnvironmentValues? = nil) {
     rootRef = ref
     rootRef.style = """
     display: flex;
@@ -102,6 +102,7 @@ public final class DOMRenderer: Renderer {
 
     // Establish default settings
     var environment = EnvironmentValues()
+    environment[ButtonStyleKey] = AnyButtonStyle(DefaultButtonStyle())
     environment[ToggleStyleKey] = _AnyToggleStyle(DefaultToggleStyle())
     environment[keyPath: \._defaultAppStorage] = LocalStorage.standard
     _DefaultSceneStorageProvider.default = SessionStorage.standard
@@ -122,7 +123,7 @@ public final class DOMRenderer: Renderer {
 
   init<A: App>(_ app: A,
                _ ref: JSObjectRef,
-               _ rootEnvironment: EnvironmentValues? = nil) {
+               _: EnvironmentValues? = nil) {
     rootRef = ref
     rootRef.style = """
     display: flex;
@@ -139,6 +140,7 @@ public final class DOMRenderer: Renderer {
 
     // Establish default settings
     var environment = EnvironmentValues()
+    environment[ButtonStyleKey] = AnyButtonStyle(DefaultButtonStyle())
     environment[ToggleStyleKey] = _AnyToggleStyle(DefaultToggleStyle())
     environment[keyPath: \._defaultAppStorage] = LocalStorage.standard
     _DefaultSceneStorageProvider.default = SessionStorage.standard

--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -102,8 +102,8 @@ public final class DOMRenderer: Renderer {
 
     // Establish default settings
     var environment = EnvironmentValues()
-    environment[ButtonStyleKey] = AnyButtonStyle(DefaultButtonStyle())
-    environment[ToggleStyleKey] = _AnyToggleStyle(DefaultToggleStyle())
+    environment[_ButtonStyleKey] = _AnyButtonStyle(DefaultButtonStyle())
+    environment[_ToggleStyleKey] = _AnyToggleStyle(DefaultToggleStyle())
     environment[keyPath: \._defaultAppStorage] = LocalStorage.standard
     _DefaultSceneStorageProvider.default = SessionStorage.standard
 
@@ -140,8 +140,8 @@ public final class DOMRenderer: Renderer {
 
     // Establish default settings
     var environment = EnvironmentValues()
-    environment[ButtonStyleKey] = AnyButtonStyle(DefaultButtonStyle())
-    environment[ToggleStyleKey] = _AnyToggleStyle(DefaultToggleStyle())
+    environment[_ButtonStyleKey] = _AnyButtonStyle(DefaultButtonStyle())
+    environment[_ToggleStyleKey] = _AnyToggleStyle(DefaultToggleStyle())
     environment[keyPath: \._defaultAppStorage] = LocalStorage.standard
     _DefaultSceneStorageProvider.default = SessionStorage.standard
 

--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -23,6 +23,7 @@ extension EnvironmentValues {
   static var defaultEnvironment: Self {
     var environment = EnvironmentValues()
     environment[_ToggleStyleKey] = _AnyToggleStyle(DefaultToggleStyle())
+    environment[_ButtonStyleKey] = _AnyButtonStyle(DefaultButtonStyle())
     environment._defaultAppStorage = LocalStorage.standard
     _DefaultSceneStorageProvider.default = SessionStorage.standard
 

--- a/Sources/TokamakDOM/Resources/TokamakStyles.swift
+++ b/Sources/TokamakDOM/Resources/TokamakStyles.swift
@@ -53,6 +53,16 @@ let tokamakStyles = """
   flex-direction: column;
   margin-left: 1em;
 }
+._tokamak-buttonstyle-reset {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  background: transparent;
+  border: none;
+  margin: 0;
+  padding: 0;
+  font-size: inherit;
+}
 """
 
 let rootNodeStyles = """

--- a/Sources/TokamakDOM/Styles/ButtonStyle.swift
+++ b/Sources/TokamakDOM/Styles/ButtonStyle.swift
@@ -12,15 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-//  Created by Max Desiatov on 11/04/2020.
+//  Created by Gene Z. Ragan on 07/22/2020.
 //
 
 import TokamakCore
 
-extension Button: ViewDeferredToRenderer where Label == Text {
-  public var deferredBody: AnyView {
-    AnyView(HTML("button", listeners: ["click": { _ in _ButtonProxy(self).action() }]) {
-      _ButtonProxy(self).label.subject
-    })
+public struct DefaultButtonStyle: ButtonStyle {
+  public func makeBody(configuration: ButtonStyleConfiguration) -> some View {
+    HTML("button",
+         listeners: ["click": { _ in
+           configuration.action()
+         }]) {
+      configuration.label
+    }
   }
 }

--- a/Sources/TokamakDOM/Styles/ButtonStyle.swift
+++ b/Sources/TokamakDOM/Styles/ButtonStyle.swift
@@ -22,3 +22,9 @@ public struct DefaultButtonStyle: ButtonStyle {
     configuration.label
   }
 }
+
+extension ButtonStyleConfiguration.Label: ViewDeferredToRenderer {
+  public var deferredBody: AnyView {
+    _ButtonStyleConfigurationProxy.Label(self).content
+  }
+}

--- a/Sources/TokamakDOM/Styles/ButtonStyle.swift
+++ b/Sources/TokamakDOM/Styles/ButtonStyle.swift
@@ -19,11 +19,6 @@ import TokamakCore
 
 public struct DefaultButtonStyle: ButtonStyle {
   public func makeBody(configuration: ButtonStyleConfiguration) -> some View {
-    HTML("button",
-         listeners: ["click": { _ in
-           configuration.action()
-         }]) {
-      configuration.label
-    }
+    configuration.label
   }
 }

--- a/Sources/TokamakDOM/Views/Buttons/Button.swift
+++ b/Sources/TokamakDOM/Views/Buttons/Button.swift
@@ -19,7 +19,18 @@ import TokamakCore
 
 extension _Button: ViewDeferredToRenderer where Label == Text {
   public var deferredBody: AnyView {
-    AnyView(HTML("button", listeners: [
+    let attributes: [String: String]
+    if buttonStyle.type == DefaultButtonStyle.self {
+      attributes = [:]
+    } else {
+      attributes = ["style": """
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      appearance: none;
+      """]
+    }
+
+    return AnyView(HTML("button", attributes, listeners: [
       "click": { _ in action() },
       "pointerdown": { _ in isPressed = true },
       "pointerup": { _ in isPressed = false },

--- a/Sources/TokamakDOM/Views/Buttons/Button.swift
+++ b/Sources/TokamakDOM/Views/Buttons/Button.swift
@@ -21,8 +21,8 @@ extension _Button: ViewDeferredToRenderer where Label == Text {
   public var deferredBody: AnyView {
     AnyView(HTML("button", listeners: [
       "click": { _ in action() },
-      "onmousedown": { _ in isPressed = true },
-      "onmouseup": { _ in isPressed = false },
+      "pointerdown": { _ in isPressed = true },
+      "pointerup": { _ in isPressed = false },
     ]) {
       buttonStyle.makeBody(
         configuration: _ButtonStyleConfigurationProxy(
@@ -31,11 +31,5 @@ extension _Button: ViewDeferredToRenderer where Label == Text {
         ).subject
       )
     })
-  }
-}
-
-extension ButtonStyleConfiguration.Label: ViewDeferredToRenderer {
-  public var deferredBody: AnyView {
-    _ButtonStyleConfigurationProxy.Label(self).content
   }
 }

--- a/Sources/TokamakDOM/Views/Buttons/Button.swift
+++ b/Sources/TokamakDOM/Views/Buttons/Button.swift
@@ -1,0 +1,41 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//  Created by Max Desiatov on 11/04/2020.
+//
+
+import TokamakCore
+
+extension _Button: ViewDeferredToRenderer where Label == Text {
+  public var deferredBody: AnyView {
+    AnyView(HTML("button", listeners: [
+      "click": { _ in action() },
+      "onmousedown": { _ in isPressed = true },
+      "onmouseup": { _ in isPressed = false },
+    ]) {
+      buttonStyle.makeBody(
+        configuration: _ButtonStyleConfigurationProxy(
+          label: AnyView(label),
+          isPressed: isPressed
+        ).subject
+      )
+    })
+  }
+}
+
+extension ButtonStyleConfiguration.Label: ViewDeferredToRenderer {
+  public var deferredBody: AnyView {
+    _ButtonStyleConfigurationProxy.Label(self).content
+  }
+}

--- a/Sources/TokamakDOM/Views/Buttons/Button.swift
+++ b/Sources/TokamakDOM/Views/Buttons/Button.swift
@@ -23,11 +23,7 @@ extension _Button: ViewDeferredToRenderer where Label == Text {
     if buttonStyle.type == DefaultButtonStyle.self {
       attributes = [:]
     } else {
-      attributes = ["style": """
-      -webkit-appearance: none;
-      -moz-appearance: none;
-      appearance: none;
-      """]
+      attributes = ["class": "_tokamak-buttonstyle-reset"]
     }
 
     return AnyView(HTML("button", attributes, listeners: [

--- a/Sources/TokamakDemo/ButtonStyleDemo.swift
+++ b/Sources/TokamakDemo/ButtonStyleDemo.swift
@@ -34,11 +34,9 @@ public struct ButtonStyleDemo: View {
     VStack {
       Button("Default Style") {
         print("tapped")
-        return
       }
       Button("Pressed Button Style") {
         print("tapped")
-        return
       }
       .buttonStyle(
         PressedButtonStyle(pressedColor: Color.red)

--- a/Sources/TokamakDemo/ButtonStyleDemo.swift
+++ b/Sources/TokamakDemo/ButtonStyleDemo.swift
@@ -12,12 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if canImport(SwiftUI)
-import SwiftUI
-#else
-import TokamakCore
-import TokamakDOM
-#endif
+import TokamakShim
 
 struct PressedButtonStyle: ButtonStyle {
   let pressedColor: Color

--- a/Sources/TokamakDemo/ButtonStyleDemo.swift
+++ b/Sources/TokamakDemo/ButtonStyleDemo.swift
@@ -1,0 +1,66 @@
+// Copyright 2020 Tokamak contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if canImport(SwiftUI)
+import SwiftUI
+#else
+import TokamakCore
+import TokamakDOM
+#endif
+
+struct PressedButtonStyle: ButtonStyle {
+  var pressedColor: Color
+
+  func makeBody(configuration: Self.Configuration) -> some View {
+    PressedButton(
+      configuration: configuration,
+      pressedColor: pressedColor
+    )
+  }
+}
+
+private extension PressedButtonStyle {
+  struct PressedButton: View {
+    @Environment(\.isEnabled) var isEnabled
+
+    let configuration: PressedButtonStyle.Configuration
+    let pressedColor: Color
+
+    var body: some View {
+      configuration.label
+        .foregroundColor(configuration.isPressed ? pressedColor : .blue)
+        .padding(15)
+    }
+  }
+}
+
+public struct ButtonStyleDemo: View {
+  @State var checked = false
+
+  public var body: some View {
+    VStack {
+      Button("Default Style") {
+        print("tapped")
+        return
+      }
+      Button("Pressed Button Style") {
+        print("tapped")
+        return
+      }
+      .buttonStyle(
+        PressedButtonStyle(pressedColor: Color.red)
+      )
+    }
+  }
+}

--- a/Sources/TokamakDemo/ButtonStyleDemo.swift
+++ b/Sources/TokamakDemo/ButtonStyleDemo.swift
@@ -20,34 +20,16 @@ import TokamakDOM
 #endif
 
 struct PressedButtonStyle: ButtonStyle {
-  var pressedColor: Color
+  let pressedColor: Color
 
-  func makeBody(configuration: Self.Configuration) -> some View {
-    PressedButton(
-      configuration: configuration,
-      pressedColor: pressedColor
-    )
-  }
-}
-
-private extension PressedButtonStyle {
-  struct PressedButton: View {
-    @Environment(\.isEnabled) var isEnabled
-
-    let configuration: PressedButtonStyle.Configuration
-    let pressedColor: Color
-
-    var body: some View {
-      configuration.label
-        .foregroundColor(configuration.isPressed ? pressedColor : .blue)
-        .padding(15)
-    }
+  func makeBody(configuration: Configuration) -> some View {
+    configuration.label
+      .foregroundColor(configuration.isPressed ? pressedColor : .blue)
+      .padding(15)
   }
 }
 
 public struct ButtonStyleDemo: View {
-  @State var checked = false
-
   public var body: some View {
     VStack {
       Button("Default Style") {

--- a/Sources/TokamakDemo/ToggleDemo.swift
+++ b/Sources/TokamakDemo/ToggleDemo.swift
@@ -26,7 +26,7 @@ public struct ToggleDemo: View {
     VStack {
       Toggle("Check me!", isOn: $checked)
       Toggle(isOn: Binding(get: { true }, set: { _ in })) {
-        Text("I’m always checked!").foregroundColor(.red).italic()
+        Group { Text("I’m always checked!").italic() }.foregroundColor(.red)
       }
     }
   }

--- a/Sources/TokamakDemo/TokamakDemo.swift
+++ b/Sources/TokamakDemo/TokamakDemo.swift
@@ -92,6 +92,7 @@ var links: [NavItem] {
         .zIndex(1)
       Text("I'm on top")
     }.padding(20)),
+    NavItem("ButtonStyle", destination: ButtonStyleDemo()),
     NavItem("ForEach", destination: ForEachDemo()),
     NavItem("Text", destination: TextDemo()),
     NavItem("Toggle", destination: ToggleDemo()),


### PR DESCRIPTION
This based off the `buttonstyles` branch by @Outcue.

Initially it didn't work because mounted host views didn't propagate their environment on updates. This is now fixed by adding `updateEnvironment` function on `MountedElement` base class and calling it in the initializer. Manual environment updates are no longer needed in `makeMounted...` factory functions. `makeMountedApp` is no longer needed at all and `MountedApp` initializer can be used directly then.