### PR TITLE
Unify code of `MountedApp`/`MountedCompositeView`

### DIFF
--- a/Sources/TokamakCore/App/_AnyApp.swift
+++ b/Sources/TokamakCore/App/_AnyApp.swift
@@ -19,13 +19,13 @@ import OpenCombine
 
 public struct _AnyApp: App {
   var app: Any
-  let appType: Any.Type
+  let type: Any.Type
   let bodyClosure: (Any) -> _AnyScene
   let bodyType: Any.Type
 
   init<A: App>(_ app: A) {
     self.app = app
-    appType = A.self
+    type = A.self
     // swiftlint:disable:next force_cast
     bodyClosure = { _AnyScene(($0 as! A).body) }
     bodyType = A.Body.self

--- a/Sources/TokamakCore/App/_AnyScene.swift
+++ b/Sources/TokamakCore/App/_AnyScene.swift
@@ -17,11 +17,11 @@
 
 public struct _AnyScene: Scene {
   let scene: Any
-  let sceneType: Any.Type
+  let type: Any.Type
 
   init<S: Scene>(_ scene: S) {
     self.scene = scene
-    sceneType = S.self
+    type = S.self
   }
 
   public var body: Never {

--- a/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
@@ -34,17 +34,19 @@ class MountedCompositeElement<R: Renderer>: MountedElement<R>, Hashable {
   var subscriptions = [AnyCancellable]()
   var environmentValues: EnvironmentValues
 
-  init(_ app: _AnyApp,
-       _ parentTarget: R.TargetType,
-       _ environmentValues: EnvironmentValues) {
+  init(_ app: _AnyApp, _ parentTarget: R.TargetType, _ environmentValues: EnvironmentValues) {
     self.parentTarget = parentTarget
     self.environmentValues = environmentValues
     super.init(app)
   }
 
-  init(_ view: AnyView,
-       _ parentTarget: R.TargetType,
-       _ environmentValues: EnvironmentValues) {
+  init(_ scene: _AnyScene, _ parentTarget: R.TargetType, _ environmentValues: EnvironmentValues) {
+    self.parentTarget = parentTarget
+    self.environmentValues = environmentValues
+    super.init(scene)
+  }
+
+  init(_ view: AnyView, _ parentTarget: R.TargetType, _ environmentValues: EnvironmentValues) {
     self.parentTarget = parentTarget
     self.environmentValues = environmentValues
     super.init(view)

--- a/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
@@ -26,8 +26,7 @@ final class MountedCompositeView<R: Renderer>: MountedCompositeElement<R> {
       appearanceAction.appear?()
     }
 
-    let child: MountedElement<R> = childBody.makeMountedView(parentTarget,
-                                                             environmentValues)
+    let child: MountedElement<R> = childBody.makeMountedView(parentTarget, environmentValues)
     mountedChildren = [child]
     child.mount(with: reconciler)
   }
@@ -41,42 +40,13 @@ final class MountedCompositeView<R: Renderer>: MountedCompositeElement<R> {
   }
 
   override func update(with reconciler: StackReconciler<R>) {
-    // FIXME: for now without properly handling `Group` mounted composite views have only
-    // a single element in `mountedChildren`, but this will change when
-    // fragments are implemented and this switch should be rewritten to compare
-    // all elements in `mountedChildren`
-    switch (mountedChildren.last, reconciler.render(compositeView: self)) {
-    // no mounted children, but children available now
-    case let (nil, childBody):
-      let child: MountedElement<R> = childBody.makeMountedView(parentTarget,
-                                                               environmentValues)
-      mountedChildren = [child]
-      child.mount(with: reconciler)
-
-    // some mounted children
-    case let (wrapper?, childBody):
-      let childBodyType = (childBody as? AnyView)?.type ?? type(of: childBody)
-
-      // FIXME: no idea if using `mangledName` is reliable, but seems to be the only way to get
-      // a name of a type constructor in runtime. Should definitely check if these are different
-      // across modules, otherwise can cause problems with views with same names in different
-      // modules.
-
-      // new child has the same type as existing child
-      // swiftlint:disable:next force_try
-      if try! wrapper.view.typeConstructorName == typeInfo(of: childBodyType).mangledName {
-        wrapper.view = AnyView(childBody)
-        wrapper.update(with: reconciler)
-      } else {
-        // new child is of a different type, complete rerender, i.e. unmount the old
-        // wrapper, then mount a new one with the new `childBody`
-        wrapper.unmount(with: reconciler)
-
-        let child: MountedElement<R> = childBody.makeMountedView(parentTarget,
-                                                                 environmentValues)
-        mountedChildren = [child]
-        child.mount(with: reconciler)
-      }
-    }
+    let element = reconciler.render(compositeView: self)
+    reconciler.reconcile(
+      self,
+      with: element,
+      getElementType: { ($0 as? AnyView)?.type ?? type(of: $0) },
+      updateChild: { $0.view = AnyView(element) },
+      mountChild: { $0.makeMountedView(parentTarget, environmentValues) }
+    )
   }
 }

--- a/Sources/TokamakCore/MountedViews/MountedElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedElement.swift
@@ -25,7 +25,7 @@ enum MountedElementKind {
 }
 
 public class MountedElement<R: Renderer> {
-  var element: MountedElementKind
+  private var element: MountedElementKind
 
   public internal(set) var app: _AnyApp {
     get {
@@ -67,8 +67,8 @@ public class MountedElement<R: Renderer> {
 
   var elementType: Any.Type {
     switch element {
-    case let .app(app): return app.appType
-    case let .scene(scene): return scene.sceneType
+    case let .app(app): return app.type
+    case let .scene(scene): return scene.type
     case let .view(view): return view.type
     }
   }
@@ -188,7 +188,7 @@ extension Scene {
     } else if let groupSelf = anySelf.scene as? GroupScene {
       return groupSelf.children[0].makeMountedView(parentTarget, environmentValues)
     } else {
-      fatalError("Unsupported `Scene` type `\(anySelf.sceneType)`. Please file a bug report.")
+      fatalError("Unsupported `Scene` type `\(anySelf.type)`. Please file a bug report.")
     }
   }
 }

--- a/Sources/TokamakCore/StackReconciler.swift
+++ b/Sources/TokamakCore/StackReconciler.swift
@@ -172,12 +172,12 @@ public final class StackReconciler<R: Renderer> {
     render(compositeElement: mountedApp, body: \.app.app, result: \.app.bodyClosure)
   }
 
-  func reconcile<E>(
+  func reconcile<Element>(
     _ mountedElement: MountedCompositeElement<R>,
-    with element: E,
-    getElementType: (E) -> Any.Type,
+    with element: Element,
+    getElementType: (Element) -> Any.Type,
     updateChild: (MountedElement<R>) -> (),
-    mountChild: (E) -> MountedElement<R>
+    mountChild: (Element) -> MountedElement<R>
   ) {
     // FIXME: for now without properly handling `Group` and `TupleView` mounted composite views
     // have only a single element in `mountedChildren`, but this will change when

--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -30,10 +30,10 @@ extension EnvironmentValues {
   }
 }
 
-/** `SpacerContainer` is part of TokamakDOM, as not all renderers will handle flexible 
- sizing the way browsers do. Their parent element could already know that if a child is 
+/** `SpacerContainer` is part of TokamakDOM, as not all renderers will handle flexible
+ sizing the way browsers do. Their parent element could already know that if a child is
  requesting full width, then it needs to expand.
-*/
+ */
 private extension AnyView {
   var axes: [SpacerContainerAxis] {
     var axes = [SpacerContainerAxis]()


### PR DESCRIPTION
We currently have the reconciler code duplicated in these types. I also have a draft `MountedScene` implementation, which most probably would rely on the same reconcilliation algorithm. In this PR it's made generic and can be shared across these types of mounted elements.