### PR TITLE
Make reconciler tests build and run on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
         with:
           shell-action: swift build --triple wasm32-unknown-wasi --product TokamakDemo
 
-  macos_demo_build:
+  macos_build:
     runs-on: macos-10.15
 
     steps:
       - uses: actions/checkout@v2
-      - name: Build macOS demo code to test compatibility with SwiftUI
+      - name: Run the test suite on macOS, build the demo project for iOS
         shell: bash
         run: |
           set -ex

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ jobs:
         run: |
           set -ex
           sudo xcode-select --switch /Applications/Xcode_12_beta.app/Contents/Developer/
+          swift test
           xcodebuild -version
           cd "NativeDemo"
           xcodebuild -scheme iOS -destination 'generic/platform=iOS' \

--- a/Package.swift
+++ b/Package.swift
@@ -39,8 +39,16 @@ let package = Package(
     // Targets can depend on other targets in this package, and on products
     // in packages which this package depends on.
     .target(
+      name: "CombineShim",
+      dependencies: [.product(
+        name: "OpenCombine",
+        package: "OpenCombine",
+        condition: .when(platforms: [.wasi, .linux])
+      )]
+    ),
+    .target(
       name: "TokamakCore",
-      dependencies: ["OpenCombine", "Runtime"]
+      dependencies: ["CombineShim", "Runtime"]
     ),
     .target(
       name: "TokamakDemo",
@@ -48,7 +56,7 @@ let package = Package(
     ),
     .target(
       name: "TokamakDOM",
-      dependencies: ["JavaScriptKit", "TokamakCore"]
+      dependencies: ["CombineShim", "JavaScriptKit", "TokamakCore"]
     ),
     .target(
       name: "TokamakShim",

--- a/Sources/CombineShim/CombineShim.swift
+++ b/Sources/CombineShim/CombineShim.swift
@@ -11,28 +11,9 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-//
-//  Created by Carson Katri on 7/20/20.
-//
 
-import CombineShim
-import JavaScriptKit
-import TokamakCore
-
-public class SessionStorage: WebStorage, _StorageProvider {
-  let storage = JSObjectRef.global.sessionStorage.object!
-
-  required init() {
-    subscription = Self.rootPublisher.sink { _ in
-      self.publisher.send()
-    }
-  }
-
-  public static var standard: _StorageProvider {
-    Self()
-  }
-
-  var subscription: AnyCancellable?
-  static let rootPublisher = ObservableObjectPublisher()
-  public let publisher = ObservableObjectPublisher()
-}
+#if canImport(Combine)
+@_exported import Combine
+#else
+@_exported import OpenCombine
+#endif

--- a/Sources/TokamakCore/App/App.swift
+++ b/Sources/TokamakCore/App/App.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/16/20.
 //
 
-import OpenCombine
+import CombineShim
 import Runtime
 
 /// Provides the ability to set the title of the Scene.

--- a/Sources/TokamakCore/App/AppStorage.swift
+++ b/Sources/TokamakCore/App/AppStorage.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/16/20.
 //
 
-import OpenCombine
+import CombineShim
 
 @propertyWrapper public struct AppStorage<Value>: DynamicProperty {
   let provider: _StorageProvider?

--- a/Sources/TokamakCore/App/Scenes/SceneStorage.swift
+++ b/Sources/TokamakCore/App/Scenes/SceneStorage.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/17/20.
 //
 
-import OpenCombine
+import CombineShim
 
 /// The renderer must specify a default `_StorageProvider` before any `SceneStorage`
 /// values are accessed.

--- a/Sources/TokamakCore/App/_AnyApp.swift
+++ b/Sources/TokamakCore/App/_AnyApp.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/19/20.
 //
 
-import OpenCombine
+import CombineShim
 
 public struct _AnyApp: App {
   var app: Any

--- a/Sources/TokamakCore/App/_StorageProvider.swift
+++ b/Sources/TokamakCore/App/_StorageProvider.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/22/20.
 //
 
-import OpenCombine
+import CombineShim
 
 public protocol _StorageProvider {
   func store(key: String, value: Bool?)

--- a/Sources/TokamakCore/Environment/EnvironmentObject.swift
+++ b/Sources/TokamakCore/Environment/EnvironmentObject.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/7/20.
 //
 
-import OpenCombine
+import CombineShim
 
 @propertyWrapper public struct EnvironmentObject<ObjectType>: DynamicProperty
   where ObjectType: ObservableObject {

--- a/Sources/TokamakCore/Environment/EnvironmentValues.swift
+++ b/Sources/TokamakCore/Environment/EnvironmentValues.swift
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import OpenCombine
+import CombineShim
 
 public struct EnvironmentValues: CustomStringConvertible {
   public var description: String {

--- a/Sources/TokamakCore/MountedViews/MountedApp.swift
+++ b/Sources/TokamakCore/MountedViews/MountedApp.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/19/20.
 //
 
-import OpenCombine
+import CombineShim
 import Runtime
 
 // This is very similar to `MountedCompositeView`. However, the `mountedBody`

--- a/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
@@ -15,7 +15,7 @@
 //  Created by Carson Katri on 7/19/20.
 //
 
-import OpenCombine
+import CombineShim
 
 class MountedCompositeElement<R: Renderer>: MountedElement<R>, Hashable {
   static func == (lhs: MountedCompositeElement<R>,

--- a/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeView.swift
@@ -15,7 +15,7 @@
 //  Created by Max Desiatov on 03/12/2018.
 //
 
-import OpenCombine
+import CombineShim
 import Runtime
 
 final class MountedCompositeView<R: Renderer>: MountedCompositeElement<R> {

--- a/Sources/TokamakCore/StackReconciler.swift
+++ b/Sources/TokamakCore/StackReconciler.swift
@@ -15,7 +15,7 @@
 //  Created by Max Desiatov on 28/11/2018.
 //
 
-import OpenCombine
+import CombineShim
 import Runtime
 
 /** A class that reconciles a "raw" tree of element values (such as `App`, `Scene` and `View`,

--- a/Sources/TokamakCore/State/ObservedObject.swift
+++ b/Sources/TokamakCore/State/ObservedObject.swift
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import OpenCombine
+import CombineShim
 
-public typealias ObservableObject = OpenCombine.ObservableObject
-public typealias Published = OpenCombine.Published
+public typealias ObservableObject = CombineShim.ObservableObject
+public typealias Published = CombineShim.Published
 
 protocol ObservedProperty: DynamicProperty {
   var objectWillChange: AnyPublisher<(), Never> { get }

--- a/Sources/TokamakDOM/App.swift
+++ b/Sources/TokamakDOM/App.swift
@@ -15,8 +15,8 @@
 //  Created by Carson Katri on 7/16/20.
 //
 
+import CombineShim
 import JavaScriptKit
-import OpenCombine
 import TokamakCore
 
 private enum ScenePhaseObserver {

--- a/Sources/TokamakDOM/Storage/LocalStorage.swift
+++ b/Sources/TokamakDOM/Storage/LocalStorage.swift
@@ -15,8 +15,8 @@
 //  Created by Carson Katri on 7/20/20.
 //
 
+import CombineShim
 import JavaScriptKit
-import OpenCombine
 import TokamakCore
 
 public class LocalStorage: WebStorage, _StorageProvider {

--- a/Sources/TokamakDOM/Storage/WebStorage.swift
+++ b/Sources/TokamakDOM/Storage/WebStorage.swift
@@ -15,8 +15,8 @@
 //  Created by Carson Katri on 7/21/20.
 //
 
+import CombineShim
 import JavaScriptKit
-import OpenCombine
 import TokamakCore
 
 protocol WebStorage {

--- a/Tests/TokamakTests/ReconcilerTests.swift
+++ b/Tests/TokamakTests/ReconcilerTests.swift
@@ -15,31 +15,58 @@
 //  Created by Max Desiatov on 07/12/2018.
 //
 
-import TokamakDemo
 import TokamakTestRenderer
 import XCTest
 
 @testable import TokamakCore
 
+struct Counter: View {
+  @State var count: Int
+
+  let limit: Int
+
+  @ViewBuilder public var body: some View {
+    if count < limit {
+      VStack {
+        Button("Increment") { count += 1 }
+        Text("\(count)")
+      }
+    } else {
+      VStack { Text("Limit exceeded") }
+    }
+  }
+}
+
+extension Text {
+  var verbatim: String? {
+    guard case let .verbatim(text) = storage else { return nil }
+    return text
+  }
+}
+
 final class ReconcilerTests: XCTestCase {
   func testMount() {
-    let renderer = TestRenderer(Counter(42))
+    let renderer = TestRenderer(Counter(count: 42, limit: 45))
     let root = renderer.rootTarget
 
     XCTAssertTrue(root.view.view is EmptyView)
     XCTAssertEqual(root.subviews.count, 1)
-    let stack = root.subviews[0]
-    XCTAssertTrue(stack.view.view is HStack<TupleView<(Button<Text>, Text)>>)
+    let conditional = root.subviews[0]
+    XCTAssertTrue(
+      conditional.view.view is
+        _ConditionalContent<VStack<TupleView<(Button<Text>, Text)>>, VStack<Text>>
+    )
+    let stack = conditional.subviews[0]
     XCTAssertEqual(stack.subviews.count, 2)
     XCTAssertTrue(stack.subviews[0].view.view is Button<Text>)
     XCTAssertTrue(stack.subviews[1].view.view is Text)
-    XCTAssertEqual((stack.subviews[1].view.view as? Text)?.content, "42")
+    XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "42")
   }
 
   func testUpdate() {
-    let renderer = TestRenderer(Counter(42))
+    let renderer = TestRenderer(Counter(count: 42, limit: 45))
     let root = renderer.rootTarget
-    let stack = root.subviews[0]
+    let stack = root.subviews[0].subviews[0]
 
     guard let button = stack.subviews[0].view.view as? Button<Text> else {
       XCTAssert(false, "counter has no button")
@@ -52,17 +79,17 @@ final class ReconcilerTests: XCTestCase {
 
     let e = expectation(description: "rerender")
 
-    DispatchQueue.main.async {
+    testScheduler {
       XCTAssertTrue(root.view.view is EmptyView)
       XCTAssertEqual(root.subviews.count, 1)
-      let newStack = root.subviews[0]
+      let newStack = root.subviews[0].subviews[0]
       XCTAssert(stack === newStack)
-      XCTAssertTrue(stack.view.view is HStack<TupleView<(Button<Text>, Text)>>)
+      XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
       XCTAssertEqual(stack.subviews.count, 2)
       XCTAssertTrue(stack.subviews[0].view.view is Button<Text>)
       XCTAssertTrue(stack.subviews[1].view.view is Text)
       XCTAssertTrue(originalLabel === newStack.subviews[1])
-      XCTAssertEqual((stack.subviews[1].view.view as? Text)?.content, "43")
+      XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "43")
 
       e.fulfill()
     }
@@ -71,9 +98,9 @@ final class ReconcilerTests: XCTestCase {
   }
 
   func testDoubleUpdate() {
-    let renderer = TestRenderer(Counter(42))
+    let renderer = TestRenderer(Counter(count: 42, limit: 45))
     let root = renderer.rootTarget
-    let stack = root.subviews[0]
+    let stack = root.subviews[0].subviews[0]
 
     guard let button = stack.subviews[0].view.view as? Button<Text> else {
       XCTAssert(false, "counter has no button")
@@ -86,17 +113,17 @@ final class ReconcilerTests: XCTestCase {
 
     let e = expectation(description: "rerender")
 
-    DispatchQueue.main.async {
+    testScheduler {
       XCTAssertTrue(root.view.view is EmptyView)
       XCTAssertEqual(root.subviews.count, 1)
-      let newStack = root.subviews[0]
+      let newStack = root.subviews[0].subviews[0]
       XCTAssert(stack === newStack)
-      XCTAssertTrue(stack.view.view is HStack<TupleView<(Button<Text>, Text)>>)
+      XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
       XCTAssertEqual(stack.subviews.count, 2)
       XCTAssertTrue(stack.subviews[0].view.view is Button<Text>)
       XCTAssertTrue(stack.subviews[1].view.view is Text)
       XCTAssertTrue(originalLabel === newStack.subviews[1])
-      XCTAssertEqual((stack.subviews[1].view.view as? Text)?.content, "43")
+      XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "43")
 
       guard let button = stack.subviews[0].view.view as? Button<Text> else {
         XCTAssert(false, "counter has no button")
@@ -105,17 +132,17 @@ final class ReconcilerTests: XCTestCase {
 
       button.action()
 
-      DispatchQueue.main.async {
+      testScheduler {
         XCTAssertTrue(root.view.view is EmptyView)
         XCTAssertEqual(root.subviews.count, 1)
-        let newStack = root.subviews[0]
+        let newStack = root.subviews[0].subviews[0]
         XCTAssert(stack === newStack)
-        XCTAssertTrue(stack.view.view is HStack<TupleView<(Button<Text>, Text)>>)
+        XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
         XCTAssertEqual(stack.subviews.count, 2)
         XCTAssertTrue(stack.subviews[0].view.view is Button<Text>)
         XCTAssertTrue(stack.subviews[1].view.view is Text)
         XCTAssertTrue(originalLabel === newStack.subviews[1])
-        XCTAssertEqual((stack.subviews[1].view.view as? Text)?.content, "44")
+        XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "44")
 
         e.fulfill()
       }
@@ -125,10 +152,10 @@ final class ReconcilerTests: XCTestCase {
   }
 
   func testUnmount() {
-    let renderer = TestRenderer(Counter(42, limit: 45))
+    let renderer = TestRenderer(Counter(count: 42, limit: 45))
     let root = renderer.rootTarget
 
-    let stack = root.subviews[0]
+    let stack = root.subviews[0].subviews[0]
     guard let button = stack.subviews[0].view.view as? Button<Text> else {
       XCTAssert(false, "counter has no button")
       return
@@ -138,7 +165,7 @@ final class ReconcilerTests: XCTestCase {
 
     let e = expectation(description: "rerender")
 
-    DispatchQueue.main.async {
+    testScheduler {
       // rerender completed here, schedule another one
       guard let button = stack.subviews[0].view.view as? Button<Text> else {
         XCTAssert(false, "counter has no button")
@@ -147,7 +174,7 @@ final class ReconcilerTests: XCTestCase {
 
       button.action()
 
-      DispatchQueue.main.async {
+      testScheduler {
         guard let button = stack.subviews[0].view.view as? Button<Text> else {
           XCTAssert(false, "counter has no button")
           return
@@ -155,13 +182,13 @@ final class ReconcilerTests: XCTestCase {
 
         button.action()
 
-        DispatchQueue.main.async {
+        testScheduler {
           XCTAssertTrue(root.view.view is EmptyView)
           XCTAssertEqual(root.subviews.count, 1)
-          let newStack = root.subviews[0]
+          let newStack = root.subviews[0].subviews[0]
           XCTAssert(stack === newStack)
-          XCTAssertTrue(stack.view.view is HStack<EmptyView>)
-          XCTAssertEqual(stack.subviews.count, 0)
+          XCTAssertTrue(stack.view.view is VStack<Text>)
+          XCTAssertEqual(stack.subviews.count, 1)
 
           e.fulfill()
         }


### PR DESCRIPTION
We can't run our basic reconciler tests in a WASI environment yet because `XCTestExpectation` is not available on WASI as it relies on the presence of `Dispatch`. We can run these tests on macOS though, and even on Linux in the future when Swift 5.3 is available for Linux on GitHub Actions.

My current OpenCombine fork doesn't build on macOS and it was much easier to add a new `CombineShim` module that uses native Combine there.