### PR TITLE
Fix tests, move `DefaultButtonStyle` to TokamakCore

### DIFF
--- a/Sources/TokamakCore/Styles/ButtonStyle.swift
+++ b/Sources/TokamakCore/Styles/ButtonStyle.swift
@@ -26,6 +26,13 @@ public struct ButtonStyleConfiguration {
   public let isPressed: Bool
 }
 
+public struct DefaultButtonStyle: ButtonStyle {
+  public init() {}
+  public func makeBody(configuration: ButtonStyleConfiguration) -> some View {
+    configuration.label
+  }
+}
+
 /// This is a helper class that works around absence of "package private" access control in Swift
 public struct _ButtonStyleConfigurationProxy {
   public struct Label {
@@ -75,7 +82,7 @@ public struct _AnyButtonStyle: ButtonStyle {
 
 public enum _ButtonStyleKey: EnvironmentKey {
   public static var defaultValue: _AnyButtonStyle {
-    fatalError("\(self) must have a renderer-provided default value")
+    _AnyButtonStyle(DefaultButtonStyle())
   }
 }
 

--- a/Sources/TokamakCore/Views/Buttons/Button.swift
+++ b/Sources/TokamakCore/Views/Buttons/Button.swift
@@ -36,14 +36,14 @@
 ///       Button("\(counter)", action: { counter += 1 })
 ///     }
 public struct Button<Label>: View where Label: View {
-  let button: _Button<Label>
+  let implementation: _Button<Label>
 
   public init(action: @escaping () -> (), @ViewBuilder label: () -> Label) {
-    button = _Button(action: action, label: label())
+    implementation = _Button(action: action, label: label())
   }
 
   public var body: some View {
-    button
+    implementation
   }
 }
 
@@ -73,6 +73,6 @@ extension Button where Label == Text {
 
 extension Button: ParentView {
   public var children: [AnyView] {
-    (button.label as? GroupView)?.children ?? [AnyView(button.label)]
+    (implementation.label as? GroupView)?.children ?? [AnyView(implementation.label)]
   }
 }

--- a/Sources/TokamakDOM/DOMRenderer.swift
+++ b/Sources/TokamakDOM/DOMRenderer.swift
@@ -23,7 +23,6 @@ extension EnvironmentValues {
   static var defaultEnvironment: Self {
     var environment = EnvironmentValues()
     environment[_ToggleStyleKey] = _AnyToggleStyle(DefaultToggleStyle())
-    environment[_ButtonStyleKey] = _AnyButtonStyle(DefaultButtonStyle())
     environment._defaultAppStorage = LocalStorage.standard
     _DefaultSceneStorageProvider.default = SessionStorage.standard
 

--- a/Sources/TokamakDOM/Styles/ButtonStyle.swift
+++ b/Sources/TokamakDOM/Styles/ButtonStyle.swift
@@ -17,12 +17,6 @@
 
 import TokamakCore
 
-public struct DefaultButtonStyle: ButtonStyle {
-  public func makeBody(configuration: ButtonStyleConfiguration) -> some View {
-    configuration.label
-  }
-}
-
 extension ButtonStyleConfiguration.Label: ViewDeferredToRenderer {
   public var deferredBody: AnyView {
     _ButtonStyleConfigurationProxy.Label(self).content

--- a/Sources/TokamakTestRenderer/TestView.swift
+++ b/Sources/TokamakTestRenderer/TestView.swift
@@ -27,11 +27,13 @@ public final class TestView: Target {
   /// Parent `TestView` instance that owns this instance as a child
   private weak var parent: TestView?
 
+  public var view: AnyView
+
   /** Initialize a new test view. */
   init<V: View>(_ view: V,
                 _ subviews: [TestView] = []) {
     self.subviews = subviews
-    super.init(view)
+    self.view = AnyView(view)
   }
 
   /** Add a subview to this test view.

--- a/Tests/TokamakTests/ReconcilerTests.swift
+++ b/Tests/TokamakTests/ReconcilerTests.swift
@@ -58,7 +58,7 @@ final class ReconcilerTests: XCTestCase {
     )
     let stack = conditional.subviews[0]
     XCTAssertEqual(stack.subviews.count, 2)
-    XCTAssertTrue(stack.subviews[0].view.view is Button<Text>)
+    XCTAssertTrue(stack.subviews[0].view.view is _Button<Text>)
     XCTAssertTrue(stack.subviews[1].view.view is Text)
     XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "42")
   }
@@ -68,7 +68,7 @@ final class ReconcilerTests: XCTestCase {
     let root = renderer.rootTarget
     let stack = root.subviews[0].subviews[0]
 
-    guard let button = stack.subviews[0].view.view as? Button<Text> else {
+    guard let button = stack.subviews[0].view.view as? _Button<Text> else {
       XCTAssert(false, "counter has no button")
       return
     }
@@ -86,7 +86,7 @@ final class ReconcilerTests: XCTestCase {
       XCTAssert(stack === newStack)
       XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
       XCTAssertEqual(stack.subviews.count, 2)
-      XCTAssertTrue(stack.subviews[0].view.view is Button<Text>)
+      XCTAssertTrue(stack.subviews[0].view.view is _Button<Text>)
       XCTAssertTrue(stack.subviews[1].view.view is Text)
       XCTAssertTrue(originalLabel === newStack.subviews[1])
       XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "43")
@@ -102,7 +102,7 @@ final class ReconcilerTests: XCTestCase {
     let root = renderer.rootTarget
     let stack = root.subviews[0].subviews[0]
 
-    guard let button = stack.subviews[0].view.view as? Button<Text> else {
+    guard let button = stack.subviews[0].view.view as? _Button<Text> else {
       XCTAssert(false, "counter has no button")
       return
     }
@@ -120,12 +120,12 @@ final class ReconcilerTests: XCTestCase {
       XCTAssert(stack === newStack)
       XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
       XCTAssertEqual(stack.subviews.count, 2)
-      XCTAssertTrue(stack.subviews[0].view.view is Button<Text>)
+      XCTAssertTrue(stack.subviews[0].view.view is _Button<Text>)
       XCTAssertTrue(stack.subviews[1].view.view is Text)
       XCTAssertTrue(originalLabel === newStack.subviews[1])
       XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "43")
 
-      guard let button = stack.subviews[0].view.view as? Button<Text> else {
+      guard let button = stack.subviews[0].view.view as? _Button<Text> else {
         XCTAssert(false, "counter has no button")
         return
       }
@@ -139,7 +139,7 @@ final class ReconcilerTests: XCTestCase {
         XCTAssert(stack === newStack)
         XCTAssertTrue(stack.view.view is VStack<TupleView<(Button<Text>, Text)>>)
         XCTAssertEqual(stack.subviews.count, 2)
-        XCTAssertTrue(stack.subviews[0].view.view is Button<Text>)
+        XCTAssertTrue(stack.subviews[0].view.view is _Button<Text>)
         XCTAssertTrue(stack.subviews[1].view.view is Text)
         XCTAssertTrue(originalLabel === newStack.subviews[1])
         XCTAssertEqual((stack.subviews[1].view.view as? Text)?.verbatim, "44")
@@ -156,7 +156,7 @@ final class ReconcilerTests: XCTestCase {
     let root = renderer.rootTarget
 
     let stack = root.subviews[0].subviews[0]
-    guard let button = stack.subviews[0].view.view as? Button<Text> else {
+    guard let button = stack.subviews[0].view.view as? _Button<Text> else {
       XCTAssert(false, "counter has no button")
       return
     }
@@ -167,7 +167,7 @@ final class ReconcilerTests: XCTestCase {
 
     testScheduler {
       // rerender completed here, schedule another one
-      guard let button = stack.subviews[0].view.view as? Button<Text> else {
+      guard let button = stack.subviews[0].view.view as? _Button<Text> else {
         XCTAssert(false, "counter has no button")
         return
       }
@@ -175,7 +175,7 @@ final class ReconcilerTests: XCTestCase {
       button.action()
 
       testScheduler {
-        guard let button = stack.subviews[0].view.view as? Button<Text> else {
+        guard let button = stack.subviews[0].view.view as? _Button<Text> else {
           XCTAssert(false, "counter has no button")
           return
         }


### PR DESCRIPTION
Merging #214 broke the tests. Also, `DefaultButtonStyle` seems to be trivial enough to be shared through `TokamakCore` between all renderers.