### PR TITLE
Temporily disable Native Demo build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           sudo xcode-select --switch /Applications/Xcode_12_beta.app/Contents/Developer/
           swift test
           xcodebuild -version
-          cd "NativeDemo"
-          xcodebuild -scheme iOS -destination 'generic/platform=iOS' \
-            CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
-            xcpretty --color
+          #cd "NativeDemo"
+          #xcodebuild -scheme iOS -destination 'generic/platform=iOS' \
+          #  CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | \
+          #  xcpretty --color


### PR DESCRIPTION
Only until Xcode 12 beta 3 is available on GHA.