### PR TITLE
Fix color scheme observer crashes in Safari

### DIFF
--- a/Sources/TokamakDOM/App/ColorSchemeObserver.swift
+++ b/Sources/TokamakDOM/App/ColorSchemeObserver.swift
@@ -27,7 +27,7 @@ enum ColorSchemeObserver {
       publisher.value = .init(matchMediaDarkScheme: $0[0].object!)
       return .undefined
     }
-    _ = matchMediaDarkScheme.addEventListener!("change", closure)
+    _ = matchMediaDarkScheme.addListener!(closure)
     Self.closure = closure
   }
 }


### PR DESCRIPTION
Resolve #245. Turns out `matchMediaDarkScheme` object doesn't have `addEventListener`, but only `addListener` in Safari 13.1.2. IDK why this wasn't reproduced elsewhere, maybe it was changed in Safari minor version that you don't have yet? `¯\_(ツ)_/¯`