### PR TITLE
Fix `NavigationView` broken state after re-render

### DIFF
--- a/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
@@ -20,8 +20,22 @@ import CombineShim
 class MountedCompositeElement<R: Renderer>: MountedElement<R> {
   let parentTarget: R.TargetType
 
+  /** An array that stores type-erased values captured with the `@State` property wrappers used
+   in declarations of this element.
+   */
   var state = [Any]()
-  var subscriptions = [AnyCancellable]()
+
+  /** An array that stores subscriptions to updates on `@ObservableObject` property wrappers used
+    in declarations of this element. These subscriptions are transient and may be cleaned up on
+    every re-render of this composite element.
+   */
+  var transientSubscriptions = [AnyCancellable]()
+
+  /** An array that stores subscriptions to updates on `@StateObject` property wrappers and renderer
+    observers. These subscriptions are persistent and are only cleaned up when this composite
+    element is deallocated.
+   */
+  var persistentSubscriptions = [AnyCancellable]()
 
   init<A: App>(_ app: A, _ parentTarget: R.TargetType, _ environmentValues: EnvironmentValues) {
     self.parentTarget = parentTarget

--- a/Sources/TokamakCore/State/ObservedObject.swift
+++ b/Sources/TokamakCore/State/ObservedObject.swift
@@ -32,7 +32,8 @@ public struct ObservedObject<ObjectType>: DynamicProperty where ObjectType: Obse
       .init(
         get: {
           self.root[keyPath: keyPath]
-        }, set: {
+        },
+        set: {
           self.root[keyPath: keyPath] = $0
         }
       )


### PR DESCRIPTION
After #241 was merged, `NavigationView` started using `@ObservedObject` instead of `@State` for its destination storage. This uncovered a bug where `@ObservedObject` properties that have their values provided in-place lost their subscriptions after a re-renderer. This manifested in navigation links not working in the demo after any scene phase changes that trigger a re-render. This was caused by a new `NavigationContext` being created on every render, but a corresponding `MountedCompositeElement` instance kept dangling subscription to the old `NavigationContext` instance, while new subscriptions weren't created.

This PR splits subscriptions on `MountedCompositeElement` into separate "transient" and "persistent" arrays. Persistent subscriptions are set up once when an element is mounted, and are automatically cleaned up when the element is unmounted. Scene phase and color scheme subscriptions on `MountedApp` are now primary examples of these persistent subscriptions, but `@StateObject` is another future use case to be implemented in a separate PR. Transient subscriptions are recreated on every re-render to allow new `@ObservedObject` instances to establish their subscriptions.

`NavigationView` in the demo still resets to the empty destination view when the scene phase observer is triggered, but `NavigationLink` selections are fixed now. Resetting to the empty destination view on scene phase changes will be fixed when `@StateObject` implementation is available in a separate PR.