### PR TITLE
Implement `StateObject` property wrapper

### DIFF
--- a/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
@@ -20,10 +20,10 @@ import CombineShim
 class MountedCompositeElement<R: Renderer>: MountedElement<R> {
   let parentTarget: R.TargetType
 
-  /** An array that stores type-erased values captured with the `@State` property wrappers used
-   in declarations of this element.
+  /** An array that stores type-erased values captured with the `@State` and `@StateObject` property
+    wrappers used in declarations of this element.
    */
-  var state = [Any]()
+  var storage = [Any]()
 
   /** An array that stores subscriptions to updates on `@ObservableObject` property wrappers used
     in declarations of this element. These subscriptions are transient and may be cleaned up on

--- a/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
+++ b/Sources/TokamakCore/MountedViews/MountedCompositeElement.swift
@@ -20,8 +20,22 @@ import CombineShim
 class MountedCompositeElement<R: Renderer>: MountedElement<R> {
   let parentTarget: R.TargetType
 
+  /** An array that stores type-erased values captured with the `@State` property wrappers used
+   in declarations of this element.
+   */
   var state = [Any]()
-  var subscriptions = [AnyCancellable]()
+
+  /** An array that stores subscriptions to updates on `@ObservableObject` property wrappers used
+    in declarations of this element. These subscriptions are transient and may be cleaned up on
+    every re-render of this composite element.
+   */
+  var transientSubscriptions = [AnyCancellable]()
+
+  /** An array that stores subscriptions to updates on `@StateObject` property wrappers and renderer
+    observers. These subscriptions are persistent and are only cleaned up when this composite
+    element is deallocated.
+   */
+  var persistentSubscriptions = [AnyCancellable]()
 
   init<A: App>(_ app: A, _ parentTarget: R.TargetType, _ environmentValues: EnvironmentValues) {
     self.parentTarget = parentTarget

--- a/Sources/TokamakCore/State/ObservedObject.swift
+++ b/Sources/TokamakCore/State/ObservedObject.swift
@@ -32,7 +32,8 @@ public struct ObservedObject<ObjectType>: DynamicProperty where ObjectType: Obse
       .init(
         get: {
           self.root[keyPath: keyPath]
-        }, set: {
+        },
+        set: {
           self.root[keyPath: keyPath] = $0
         }
       )

--- a/Sources/TokamakCore/State/ObservedObject.swift
+++ b/Sources/TokamakCore/State/ObservedObject.swift
@@ -47,10 +47,10 @@ public struct ObservedObject<ObjectType>: DynamicProperty where ObjectType: Obse
   }
 
   public let projectedValue: Wrapper
+}
 
+extension ObservedObject: ObservedProperty {
   var objectWillChange: AnyPublisher<(), Never> {
     wrappedValue.objectWillChange.map { _ in }.eraseToAnyPublisher()
   }
 }
-
-extension ObservedObject: ObservedProperty {}

--- a/Sources/TokamakCore/State/State.swift
+++ b/Sources/TokamakCore/State/State.swift
@@ -16,8 +16,11 @@
 //
 protocol ValueStorage {
   var getter: (() -> Any)? { get set }
-  var setter: ((Any) -> ())? { get set }
   var anyInitialValue: Any { get }
+}
+
+protocol WritableValueStorage: ValueStorage {
+  var setter: ((Any) -> ())? { get set }
 }
 
 @propertyWrapper public struct State<Value>: DynamicProperty {
@@ -46,7 +49,7 @@ protocol ValueStorage {
   }
 }
 
-extension State: ValueStorage {}
+extension State: WritableValueStorage {}
 
 extension State where Value: ExpressibleByNilLiteral {
   @inlinable

--- a/Sources/TokamakCore/Views/Navigation/NavigationView.swift
+++ b/Sources/TokamakCore/Views/Navigation/NavigationView.swift
@@ -22,7 +22,7 @@ final class NavigationContext: ObservableObject {
 public struct NavigationView<Content>: View where Content: View {
   let content: Content
 
-  @ObservedObject var context = NavigationContext()
+  @StateObject var context = NavigationContext()
 
   public init(@ViewBuilder content: () -> Content) {
     self.content = content()

--- a/Sources/TokamakDOM/Core.swift
+++ b/Sources/TokamakDOM/Core.swift
@@ -27,6 +27,7 @@ public typealias ObservableObject = TokamakCore.ObservableObject
 public typealias ObservedObject = TokamakCore.ObservedObject
 public typealias Published = TokamakCore.Published
 public typealias State = TokamakCore.State
+public typealias StateObject = TokamakCore.StateObject
 
 // MARK: Modifiers & Styles
 


### PR DESCRIPTION
Resolves #158.

Fixes a bug where `NavigationView` destination was reset after scene phase changes (or any re-renders caused by environment changes for that matter).

This was caused by `@ObservedObject` destination being recreated, now `@StateObject` persists it across re-renders.

The `setter` property of the `ValueStorage` protocol is now moved to a separate `WritableValueStorage` protocol. The reasoning is that `StateObject` doesn't need its wrapped value to be set directly as it operates on it by reference, not by value, thus `StateObject` doesn't need any wrapped value setters.
