### PR TITLE
Add missing JavaScriptKit import to `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ struct SVGCircle: View {
 
 ### Arbitrary styles and scripts
 
-While `JavaScriptKit` is a great option for occasional interactions with JavaScript,
+While [`JavaScriptKit`](https://github.com/swiftwasm/JavaScriptKit) is a great option for occasional interactions with JavaScript,
 sometimes you need to inject arbitrary scripts or styles, which can be done through direct
 DOM access:
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ sometimes you need to inject arbitrary scripts or styles, which can be done thro
 DOM access:
 
 ```swift
+import JavaScriptKit
+
 _ = document.head.object!.insertAdjacentHTML!("beforeend", #"""
 <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.27.0/moment.min.js"></script>
 """#)


### PR DESCRIPTION
The import is currently missing, which may be confusing, especially if example code is copied without any context.